### PR TITLE
fix(backend): 인증 실패 응답 표준화

### DIFF
--- a/backend/src/main/java/com/moya/myblogboot/configuration/JwtFilter.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/JwtFilter.java
@@ -2,6 +2,7 @@ package com.moya.myblogboot.configuration;
 
 import com.moya.myblogboot.constants.ShouldNotFilterPath;
 import com.moya.myblogboot.domain.token.TokenInfo;
+import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.service.AuthService;
@@ -44,23 +45,23 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = authorization.substring(7);
         if (token.isEmpty()) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+            SecurityErrorResponseWriter.write(response, ErrorCode.INVALID_TOKEN);
             return;
         }
 
         try {
             JwtUtil.validateAccessToken(token, secret);
         } catch (SecurityException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            SecurityErrorResponseWriter.write(response, ErrorCode.INVALID_TOKEN);
             return;
         } catch (ExpiredTokenException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            SecurityErrorResponseWriter.write(response, ErrorCode.EXPIRED_TOKEN);
             return;
         } catch (InvalidateTokenException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            SecurityErrorResponseWriter.write(response, e.getErrorCode());
             return;
         } catch (MalformedJwtException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            SecurityErrorResponseWriter.write(response, ErrorCode.INVALID_TOKEN);
             return;
         }
 

--- a/backend/src/main/java/com/moya/myblogboot/configuration/SecurityErrorResponseWriter.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/SecurityErrorResponseWriter.java
@@ -1,0 +1,25 @@
+package com.moya.myblogboot.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public final class SecurityErrorResponseWriter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SecurityErrorResponseWriter() {
+    }
+
+    public static void write(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatusValue());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        OBJECT_MAPPER.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/configuration/WebSecurityConfig.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.moya.myblogboot.configuration;
 
 import com.moya.myblogboot.service.AuthService;
+import com.moya.myblogboot.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +52,12 @@ public class WebSecurityConfig {
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) ->
+                                SecurityErrorResponseWriter.write(response, ErrorCode.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                SecurityErrorResponseWriter.write(response, ErrorCode.ACCESS_DENIED))
                 )
                 .addFilterBefore(new JwtFilter(authService, secret), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "리프레시 토큰이 만료되었습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A006", "비밀번호가 일치하지 않습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A007", "아이디 또는 비밀번호가 일치하지 않습니다."),
 
     // 어드민
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "회원이 존재하지 않습니다."),

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
@@ -5,7 +5,6 @@ import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.domain.token.TokenInfo;
 import com.moya.myblogboot.exception.ErrorCode;
-import com.moya.myblogboot.exception.custom.EntityNotFoundException;
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
@@ -40,9 +39,14 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public Token adminLogin(LoginReqDto loginReqDto) {
         Admin admin = adminRepository.findByUsername(loginReqDto.getUsername())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-        if (!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword()))
-            throw new UnauthorizedException(ErrorCode.INVALID_PASSWORD);
+                .orElseThrow(() -> {
+                    log.warn("Admin login failed: username not found");
+                    return new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+                });
+        if (!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword())) {
+            log.warn("Admin login failed: invalid password");
+            throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+        }
         return JwtUtil.createToken(admin, accessTokenExpiration, refreshTokenExpiration, secret);
     }
 

--- a/backend/src/test/java/com/moya/myblogboot/configuration/JwtFilterTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/configuration/JwtFilterTest.java
@@ -1,0 +1,40 @@
+package com.moya.myblogboot.configuration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class JwtFilterTest {
+
+    private static final String SECRET = "12345678901234567890123456789012";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Invalid bearer token returns ErrorResponse JSON")
+    void invalidBearerTokenReturnsErrorResponseJson() throws Exception {
+        JwtFilter jwtFilter = new JwtFilter(mock(AuthService.class), SECRET);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer invalid-token");
+
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        JsonNode body = objectMapper.readTree(response.getContentAsString());
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_TOKEN.getStatusValue());
+        assertThat(response.getContentType()).contains("application/json");
+        assertThat(body.get("code").asText()).isEqualTo(ErrorCode.INVALID_TOKEN.getCode());
+        assertThat(body.get("status").asInt()).isEqualTo(ErrorCode.INVALID_TOKEN.getStatusValue());
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/configuration/SecurityErrorResponseWriterTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/configuration/SecurityErrorResponseWriterTest.java
@@ -1,0 +1,30 @@
+package com.moya.myblogboot.configuration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moya.myblogboot.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityErrorResponseWriterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Security errors are written as ErrorResponse JSON")
+    void write() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        SecurityErrorResponseWriter.write(response, ErrorCode.INVALID_TOKEN);
+
+        JsonNode body = objectMapper.readTree(response.getContentAsString());
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_TOKEN.getStatusValue());
+        assertThat(response.getContentType()).contains(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(body.get("code").asText()).isEqualTo(ErrorCode.INVALID_TOKEN.getCode());
+        assertThat(body.get("status").asInt()).isEqualTo(ErrorCode.INVALID_TOKEN.getStatusValue());
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
@@ -177,7 +177,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
@@ -4,7 +4,6 @@ import com.moya.myblogboot.AbstractContainerBaseTest;
 import com.moya.myblogboot.domain.admin.Admin;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.Token;
-import com.moya.myblogboot.exception.custom.EntityNotFoundException;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.repository.AdminRepository;
 import com.moya.myblogboot.service.AuthService;
@@ -67,7 +66,7 @@ class AuthServiceImplTest extends AbstractContainerBaseTest {
                 .password("testPassword")
                 .build();
 
-        assertThrows(EntityNotFoundException.class, () -> authService.adminLogin(notExistsUsername));
+        assertThrows(UnauthorizedException.class, () -> authService.adminLogin(notExistsUsername));
         assertThrows(UnauthorizedException.class, () -> authService.adminLogin(wrongPassword));
         Object result = authService.adminLogin(validLogin);
         assertTrue(result instanceof Token);

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
@@ -1,0 +1,59 @@
+package com.moya.myblogboot.service.implementation;
+
+import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.dto.auth.LoginReqDto;
+import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.exception.custom.UnauthorizedException;
+import com.moya.myblogboot.repository.AdminRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplUnitTest {
+
+    @Mock
+    private AdminRepository adminRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("Login failures use the same error code")
+    void adminLoginFailureUsesSameErrorCode() {
+        AuthServiceImpl authService = new AuthServiceImpl(adminRepository, passwordEncoder);
+        LoginReqDto notExistsUsername = LoginReqDto.builder()
+                .username("notExists")
+                .password("testPassword")
+                .build();
+        LoginReqDto wrongPassword = LoginReqDto.builder()
+                .username("admin")
+                .password("wrongPassword")
+                .build();
+        Admin admin = Admin.builder()
+                .username("admin")
+                .password("encodedPassword")
+                .build();
+
+        given(adminRepository.findByUsername("notExists")).willReturn(Optional.empty());
+        given(adminRepository.findByUsername("admin")).willReturn(Optional.of(admin));
+        given(passwordEncoder.matches("wrongPassword", "encodedPassword")).willReturn(false);
+
+        assertInvalidCredentials(authService, notExistsUsername);
+        assertInvalidCredentials(authService, wrongPassword);
+    }
+
+    private void assertInvalidCredentials(AuthServiceImpl authService, LoginReqDto loginReqDto) {
+        assertThatThrownBy(() -> authService.adminLogin(loginReqDto))
+                .isInstanceOfSatisfying(UnauthorizedException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_CREDENTIALS));
+    }
+}


### PR DESCRIPTION
 ## 작업 내용

  백엔드 인증 실패 응답을 표준화하고, 로그인 실패 시 사용자 존재 여부가 노출되지 않도록
  개선했습니다.

  ### User Enumeration 방지

  - 로그인 실패 응답을 `INVALID_CREDENTIALS`로 통일
  - username 없음, 비밀번호 불일치 모두 동일한 401 응답 반환
  - 내부 실패 사유는 서버 로그에만 기록

  ### 인증 실패 응답 포맷 통일

  - `JwtFilter`의 `response.sendError(...)` 직접 호출 제거
  - `SecurityErrorResponseWriter` 추가
  - JWT 인증 실패를 기존 `ErrorResponse` JSON 포맷으로 반환
  - Spring Security `authenticationEntryPoint`, `accessDeniedHandler`도 동일한 응답
  writer 사용

  ### 테스트 보강

  - 로그인 실패가 동일한 에러 코드로 처리되는지 검증
  - Security error writer가 `ErrorResponse` JSON을 반환하는지 검증
  - 잘못된 Bearer token이 표준 JSON 에러로 반환되는지 검증
  - 기존 로그인 실패 테스트 기대값을 401로 수정

  ## 변경 파일

  - `JwtFilter`
  - `WebSecurityConfig`
  - `SecurityErrorResponseWriter`
  - `ErrorCode`
  - `AuthServiceImpl`
  - 관련 테스트 파일