### PR TITLE
feat(backend): Refresh Token Rotation 도입

### DIFF
--- a/backend/src/main/java/com/moya/myblogboot/configuration/JwtFilter.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/JwtFilter.java
@@ -1,7 +1,7 @@
 package com.moya.myblogboot.configuration;
 
 import com.moya.myblogboot.constants.ShouldNotFilterPath;
-import com.moya.myblogboot.domain.token.TokenInfo;
+import com.moya.myblogboot.domain.token.AccessTokenClaims;
 import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
@@ -65,14 +65,14 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        TokenInfo tokenInfo = JwtUtil.getTokenInfo(token, secret);
-        Long memberPrimaryKey = tokenInfo.getMemberPrimaryKey();
+        AccessTokenClaims tokenInfo = JwtUtil.parseAccessToken(token, secret);
+        Long memberPrimaryKey = tokenInfo.memberPrimaryKey();
 
         log.debug("{} {} | member={} role={}", request.getMethod(),
-                request.getRequestURI(), memberPrimaryKey, tokenInfo.getRole());
+                request.getRequestURI(), memberPrimaryKey, tokenInfo.role());
 
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(memberPrimaryKey, null, List.of(new SimpleGrantedAuthority(tokenInfo.getRole())));
+                new UsernamePasswordAuthenticationToken(memberPrimaryKey, null, List.of(new SimpleGrantedAuthority(tokenInfo.role())));
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
         filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/moya/myblogboot/configuration/RedisConfig.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/RedisConfig.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -72,5 +73,10 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
 
         return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate refreshTokenRedisTemplate(LettuceConnectionFactory lettuceConnectionFactory) {
+        return new StringRedisTemplate(lettuceConnectionFactory);
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/constants/ShouldNotFilterPath.java
+++ b/backend/src/main/java/com/moya/myblogboot/constants/ShouldNotFilterPath.java
@@ -11,8 +11,8 @@ public class ShouldNotFilterPath {
      */
     private static final List<String> EXCLUDE_ALL_METHODS = Arrays.asList(
             "/api/v1/login",            // POST  — 로그인
-            "/api/v1/logout",           // GET   — 로그아웃
-            "/api/v1/reissuing-token",  // GET   — RefreshToken → AccessToken 재발급
+            "/api/v1/logout",           // GET/POST — 로그아웃
+            "/api/v1/reissuing-token",  // GET/POST — RefreshToken 회전 및 AccessToken 재발급
             "/api/v2/likes",            // GET/POST/DELETE — 쿠키 기반, JWT 불필요
             "/api/v2/visitor-count",    // GET   — 방문자 수 조회
             "/api/v2/categories",       // GET   — 공개 카테고리 목록 (V2)

--- a/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
@@ -2,14 +2,18 @@ package com.moya.myblogboot.controller;
 
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.Token;
+import com.moya.myblogboot.domain.token.ReissuedToken;
+import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.service.AuthService;
+import com.moya.myblogboot.service.RefreshTokenService;
 import com.moya.myblogboot.utils.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,21 +26,26 @@ import static com.moya.myblogboot.constants.CookieName.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private Long refreshTokenExpiration;
 
     @PostMapping("/api/v1/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginReqDto loginReqDto,
                                         HttpServletResponse response) {
         Token newToken = authService.adminLogin(loginReqDto);
-        response.addCookie(CookieUtil.addCookie(REFRESH_TOKEN_COOKIE, newToken.getRefresh_token()));
+        addRefreshTokenCookie(response, newToken.getRefresh_token());
         return ResponseEntity.ok().body(newToken.getAccess_token());
     }
 
-    @GetMapping("/api/v1/logout")
+    @RequestMapping(value = "/api/v1/logout", method = {RequestMethod.GET, RequestMethod.POST})
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         Cookie refreshTokenCookie = CookieUtil.findCookie(request, REFRESH_TOKEN_COOKIE);
         if (refreshTokenCookie != null
                 && refreshTokenCookie.getValue() != null
                 && !refreshTokenCookie.getValue().isEmpty()) {
+            refreshTokenService.revokeOnLogout(refreshTokenCookie.getValue());
             CookieUtil.deleteCookie(response, refreshTokenCookie);
         }
         return new ResponseEntity<>(HttpStatus.OK);
@@ -47,12 +56,19 @@ public class AuthController {
         return ResponseEntity.ok().body(authService.getTokenInfo(getToken(request)).getRole());
     }
 
-    @GetMapping("/api/v1/reissuing-token")
-    public ResponseEntity<String> reissuingAccessToken(HttpServletRequest request) {
+    @RequestMapping(value = "/api/v1/reissuing-token", method = {RequestMethod.GET, RequestMethod.POST})
+    public ResponseEntity<String> reissuingAccessToken(HttpServletRequest request, HttpServletResponse response) {
         Cookie refreshTokenCookie = CookieUtil.findCookie(request, REFRESH_TOKEN_COOKIE);
         if (refreshTokenCookie == null || refreshTokenCookie.getValue().isEmpty())
             throw new InvalidateTokenException();
-        return ResponseEntity.ok().body(authService.reissuingAccessToken(refreshTokenCookie.getValue()));
+        try {
+            ReissuedToken reissuedToken = authService.reissuingAccessToken(refreshTokenCookie.getValue());
+            addRefreshTokenCookie(response, reissuedToken.refreshToken());
+            return ResponseEntity.ok().body(reissuedToken.accessToken());
+        } catch (InvalidateTokenException | ExpiredRefreshTokenException e) {
+            CookieUtil.deleteCookie(response, refreshTokenCookie);
+            throw e;
+        }
     }
 
     @GetMapping("/api/v1/token-validation")
@@ -65,5 +81,10 @@ public class AuthController {
         if (authorization == null || !authorization.toLowerCase().startsWith("bearer "))
             throw new InvalidateTokenException();
         return authorization.substring(7);
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        response.addCookie(CookieUtil.addCookie(REFRESH_TOKEN_COOKIE, refreshToken,
+                Math.toIntExact(refreshTokenExpiration / 1000)));
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/domain/keys/RedisKey.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/keys/RedisKey.java
@@ -10,4 +10,8 @@ public class RedisKey {
     public static final String TODAY_COUNT_KEY = "today";
     public static final String TOTAL_COUNT_KEY = "total";
     public static final String YESTERDAY_COUNT_KEY = "yesterday";
+
+    public static final String REFRESH_FAMILY_KEY = "refresh:{%s}:family";
+    public static final String REFRESH_TOKEN_KEY = "refresh:{%s}:token:%s";
+    public static final String REFRESH_ROTATION_RESPONSE_KEY = "refresh:{%s}:rotation-response:%s";
 }

--- a/backend/src/main/java/com/moya/myblogboot/domain/token/AccessTokenClaims.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/token/AccessTokenClaims.java
@@ -1,0 +1,4 @@
+package com.moya.myblogboot.domain.token;
+
+public record AccessTokenClaims(Long memberPrimaryKey, String role) {
+}

--- a/backend/src/main/java/com/moya/myblogboot/domain/token/IssuedToken.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/token/IssuedToken.java
@@ -1,0 +1,4 @@
+package com.moya.myblogboot.domain.token;
+
+public record IssuedToken(String accessToken, String refreshToken) {
+}

--- a/backend/src/main/java/com/moya/myblogboot/domain/token/RefreshTokenClaims.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/token/RefreshTokenClaims.java
@@ -1,0 +1,4 @@
+package com.moya.myblogboot.domain.token;
+
+public record RefreshTokenClaims(Long memberPrimaryKey, String role, String jti, String familyId) {
+}

--- a/backend/src/main/java/com/moya/myblogboot/domain/token/ReissuedToken.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/token/ReissuedToken.java
@@ -1,0 +1,4 @@
+package com.moya.myblogboot.domain.token;
+
+public record ReissuedToken(String accessToken, String refreshToken) {
+}

--- a/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "리프레시 토큰이 만료되었습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A006", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A007", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "A008", "리프레시 토큰 재사용이 감지되었습니다."),
 
     // 어드민
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "회원이 존재하지 않습니다."),

--- a/backend/src/main/java/com/moya/myblogboot/exception/custom/InvalidateTokenException.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/custom/InvalidateTokenException.java
@@ -7,4 +7,8 @@ public class InvalidateTokenException extends BusinessException {
     public InvalidateTokenException() {
         super(ErrorCode.INVALID_TOKEN);
     }
+
+    public InvalidateTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/backend/src/main/java/com/moya/myblogboot/repository/RefreshTokenRedisRepository.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,20 @@
+package com.moya.myblogboot.repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RefreshTokenRedisRepository {
+
+    void saveInitialToken(String familyId, String jti, Long adminId, Instant now,
+                          Instant absoluteExpiry, Duration familyTtl, Duration refreshTtl);
+
+    Optional<Instant> findAbsoluteExpiry(String familyId);
+
+    String rotate(String familyId, String oldJti, String newJti, Instant now,
+                  Duration refreshTtl, Duration graceWindow, String rotationResponseJson);
+
+    void revokeFamily(String familyId, Instant now, String reason);
+
+    Optional<String> findFamilyReason(String familyId);
+}

--- a/backend/src/main/java/com/moya/myblogboot/repository/implementation/RefreshTokenRedisRepositoryImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/implementation/RefreshTokenRedisRepositoryImpl.java
@@ -1,0 +1,112 @@
+package com.moya.myblogboot.repository.implementation;
+
+import com.moya.myblogboot.repository.RefreshTokenRedisRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.moya.myblogboot.domain.keys.RedisKey.REFRESH_FAMILY_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.REFRESH_ROTATION_RESPONSE_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.REFRESH_TOKEN_KEY;
+
+@Repository
+public class RefreshTokenRedisRepositoryImpl implements RefreshTokenRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private final DefaultRedisScript<String> rotateScript;
+
+    public RefreshTokenRedisRepositoryImpl(
+            @Qualifier("refreshTokenRedisTemplate") StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.rotateScript = new DefaultRedisScript<>();
+        this.rotateScript.setLocation(new ClassPathResource("scripts/refresh-token-rotate.lua"));
+        this.rotateScript.setResultType(String.class);
+    }
+
+    @Override
+    public void saveInitialToken(String familyId, String jti, Long adminId, Instant now,
+                                 Instant absoluteExpiry, Duration familyTtl, Duration refreshTtl) {
+        String familyKey = familyKey(familyId);
+        String tokenKey = tokenKey(familyId, jti);
+
+        redisTemplate.opsForHash().putAll(familyKey, Map.of(
+                "adminId", String.valueOf(adminId),
+                "familyCreatedAt", now.toString(),
+                "absoluteExpiry", absoluteExpiry.toString(),
+                "revoked", "false",
+                "revokedAt", "",
+                "reason", ""
+        ));
+        redisTemplate.expire(familyKey, familyTtl);
+
+        redisTemplate.opsForHash().putAll(tokenKey, Map.of(
+                "status", "ACTIVE",
+                "issuedAt", now.toString(),
+                "parentJti", "",
+                "nextJti", ""
+        ));
+        redisTemplate.expire(tokenKey, refreshTtl);
+    }
+
+    @Override
+    public Optional<Instant> findAbsoluteExpiry(String familyId) {
+        Object value = redisTemplate.opsForHash().get(familyKey(familyId), "absoluteExpiry");
+        return value == null ? Optional.empty() : Optional.of(Instant.parse(value.toString()));
+    }
+
+    @Override
+    public String rotate(String familyId, String oldJti, String newJti, Instant now,
+                         Duration refreshTtl, Duration graceWindow, String rotationResponseJson) {
+        List<String> keys = List.of(
+                familyKey(familyId),
+                tokenKey(familyId, oldJti),
+                tokenKey(familyId, newJti),
+                rotationResponseKey(familyId, oldJti)
+        );
+        return redisTemplate.execute(
+                rotateScript,
+                keys,
+                newJti,
+                now.toString(),
+                String.valueOf(refreshTtl.toSeconds()),
+                String.valueOf(graceWindow.toSeconds()),
+                rotationResponseJson,
+                oldJti
+        );
+    }
+
+    @Override
+    public void revokeFamily(String familyId, Instant now, String reason) {
+        redisTemplate.opsForHash().putAll(familyKey(familyId), Map.of(
+                "revoked", "true",
+                "revokedAt", now.toString(),
+                "reason", reason
+        ));
+    }
+
+    @Override
+    public Optional<String> findFamilyReason(String familyId) {
+        Object value = redisTemplate.opsForHash().get(familyKey(familyId), "reason");
+        return value == null || value.toString().isBlank() ? Optional.empty() : Optional.of(value.toString());
+    }
+
+    private String familyKey(String familyId) {
+        return String.format(REFRESH_FAMILY_KEY, familyId);
+    }
+
+    private String tokenKey(String familyId, String jti) {
+        return String.format(REFRESH_TOKEN_KEY, familyId, jti);
+    }
+
+    private String rotationResponseKey(String familyId, String jti) {
+        return String.format(REFRESH_ROTATION_RESPONSE_KEY, familyId, jti);
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
@@ -3,12 +3,13 @@ package com.moya.myblogboot.service;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.domain.token.TokenInfo;
+import com.moya.myblogboot.domain.token.ReissuedToken;
 
 public interface AuthService {
 
     Token adminLogin(LoginReqDto loginReqDto);
 
-    String reissuingAccessToken(String refreshToken);
+    ReissuedToken reissuingAccessToken(String refreshToken);
 
     TokenInfo getTokenInfo(String token);
 

--- a/backend/src/main/java/com/moya/myblogboot/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/RefreshTokenService.java
@@ -1,0 +1,14 @@
+package com.moya.myblogboot.service;
+
+import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.domain.token.IssuedToken;
+import com.moya.myblogboot.domain.token.ReissuedToken;
+
+public interface RefreshTokenService {
+
+    IssuedToken issueOnLogin(Admin admin);
+
+    ReissuedToken rotate(String presentedRefreshToken);
+
+    void revokeOnLogout(String presentedRefreshToken);
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
@@ -1,16 +1,19 @@
 package com.moya.myblogboot.service.implementation;
 
 import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.domain.token.AccessTokenClaims;
+import com.moya.myblogboot.domain.token.IssuedToken;
+import com.moya.myblogboot.domain.token.ReissuedToken;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.domain.token.TokenInfo;
 import com.moya.myblogboot.exception.ErrorCode;
-import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.repository.AdminRepository;
 import com.moya.myblogboot.service.AuthService;
+import com.moya.myblogboot.service.RefreshTokenService;
 import com.moya.myblogboot.utils.JwtUtil;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +31,10 @@ public class AuthServiceImpl implements AuthService {
 
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${jwt.secret}")
     private String secret;
-    @Value("${jwt.access-token-expiration}")
-    private Long accessTokenExpiration;
-    @Value("${jwt.refresh-token-expiration}")
-    private Long refreshTokenExpiration;
 
     @Override
     public Token adminLogin(LoginReqDto loginReqDto) {
@@ -47,23 +47,25 @@ public class AuthServiceImpl implements AuthService {
             log.warn("Admin login failed: invalid password");
             throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
         }
-        return JwtUtil.createToken(admin, accessTokenExpiration, refreshTokenExpiration, secret);
+        IssuedToken issuedToken = refreshTokenService.issueOnLogin(admin);
+        return Token.builder()
+                .access_token(issuedToken.accessToken())
+                .refresh_token(issuedToken.refreshToken())
+                .build();
     }
 
     @Override
-    public String reissuingAccessToken(String refreshToken) {
-        try {
-            JwtUtil.validateRefreshToken(refreshToken, secret);
-        } catch (ExpiredTokenException e) {
-            throw new ExpiredRefreshTokenException();
-        }
-        return JwtUtil.reissuingToken(JwtUtil.getTokenInfo(refreshToken, secret), accessTokenExpiration, secret);
+    public ReissuedToken reissuingAccessToken(String refreshToken) {
+        return refreshTokenService.rotate(refreshToken);
     }
 
     @Override
     public TokenInfo getTokenInfo(String token) {
-        JwtUtil.validateAccessToken(token, secret);
-        return JwtUtil.getTokenInfo(token, secret);
+        AccessTokenClaims claims = JwtUtil.parseAccessToken(token, secret);
+        return TokenInfo.builder()
+                .memberPrimaryKey(claims.memberPrimaryKey())
+                .role(claims.role())
+                .build();
     }
 
     @Override

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImpl.java
@@ -1,0 +1,159 @@
+package com.moya.myblogboot.service.implementation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.domain.token.IssuedToken;
+import com.moya.myblogboot.domain.token.RefreshTokenClaims;
+import com.moya.myblogboot.domain.token.ReissuedToken;
+import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
+import com.moya.myblogboot.exception.custom.ExpiredTokenException;
+import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.repository.RefreshTokenRedisRepository;
+import com.moya.myblogboot.service.RefreshTokenService;
+import com.moya.myblogboot.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+    private static final String REUSE_DETECTED = "REUSE_DETECTED";
+    private static final String LOGOUT = "LOGOUT";
+
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${jwt.secret}")
+    private String secret;
+    @Value("${jwt.access-token-expiration}")
+    private Long accessTokenExpiration;
+    @Value("${jwt.refresh-token-expiration}")
+    private Long refreshTokenExpiration;
+    @Value("${jwt.absolute-lifetime}")
+    private Long absoluteLifetime;
+    @Value("${jwt.grace-window-ms}")
+    private Long graceWindowMs;
+
+    @Override
+    public IssuedToken issueOnLogin(Admin admin) {
+        Instant now = Instant.now();
+        Instant absoluteExpiry = now.plusMillis(absoluteLifetime);
+        String familyId = UUID.randomUUID().toString();
+        String jti = UUID.randomUUID().toString();
+        String accessToken = JwtUtil.buildAccess(admin.getId(), ROLE_ADMIN, accessTokenExpiration, secret);
+        String refreshToken = JwtUtil.buildRefresh(admin.getId(), ROLE_ADMIN, jti, familyId,
+                refreshTokenExpiration, secret);
+
+        refreshTokenRedisRepository.saveInitialToken(
+                familyId,
+                jti,
+                admin.getId(),
+                now,
+                absoluteExpiry,
+                Duration.ofMillis(absoluteLifetime).plus(Duration.ofDays(30)),
+                Duration.ofMillis(refreshTokenExpiration)
+        );
+        log.info("Admin login: id={}, family={}", admin.getId(), familyId);
+        return new IssuedToken(accessToken, refreshToken);
+    }
+
+    @Override
+    public ReissuedToken rotate(String presentedRefreshToken) {
+        RefreshTokenClaims claims = parsePresentedRefreshToken(presentedRefreshToken);
+        Instant now = Instant.now();
+        Instant absoluteExpiry = refreshTokenRedisRepository.findAbsoluteExpiry(claims.familyId())
+                .orElseThrow(InvalidateTokenException::new);
+        Duration refreshTtl = remainingRefreshTtl(now, absoluteExpiry);
+        String newJti = UUID.randomUUID().toString();
+        String newAccess = JwtUtil.buildAccess(claims.memberPrimaryKey(), claims.role(),
+                accessTokenExpiration, secret);
+        String newRefresh = JwtUtil.buildRefresh(claims.memberPrimaryKey(), claims.role(), newJti,
+                claims.familyId(), refreshTtl.toMillis(), secret);
+        ReissuedToken reissuedToken = new ReissuedToken(newAccess, newRefresh);
+        String rotationResponseJson = toJson(reissuedToken);
+
+        String result = refreshTokenRedisRepository.rotate(
+                claims.familyId(),
+                claims.jti(),
+                newJti,
+                now,
+                refreshTtl,
+                Duration.ofMillis(graceWindowMs),
+                rotationResponseJson
+        );
+
+        return parseRotationResult(result, claims.familyId(), reissuedToken);
+    }
+
+    @Override
+    public void revokeOnLogout(String presentedRefreshToken) {
+        try {
+            RefreshTokenClaims claims = JwtUtil.parseRefreshToken(presentedRefreshToken, secret);
+            refreshTokenRedisRepository.revokeFamily(claims.familyId(), Instant.now(), LOGOUT);
+            log.info("Admin logout: family={}", claims.familyId());
+        } catch (ExpiredTokenException | InvalidateTokenException e) {
+            return;
+        }
+    }
+
+    private RefreshTokenClaims parsePresentedRefreshToken(String presentedRefreshToken) {
+        try {
+            return JwtUtil.parseRefreshToken(presentedRefreshToken, secret);
+        } catch (ExpiredTokenException e) {
+            throw new ExpiredRefreshTokenException();
+        }
+    }
+
+    private Duration remainingRefreshTtl(Instant now, Instant absoluteExpiry) {
+        Duration absoluteRemaining = Duration.between(now, absoluteExpiry);
+        if (absoluteRemaining.isZero() || absoluteRemaining.isNegative()) {
+            throw new ExpiredRefreshTokenException();
+        }
+        Duration refreshLifetime = Duration.ofMillis(refreshTokenExpiration);
+        return absoluteRemaining.compareTo(refreshLifetime) < 0 ? absoluteRemaining : refreshLifetime;
+    }
+
+    private ReissuedToken parseRotationResult(String result, String familyId, ReissuedToken reissuedToken) {
+        if ("OK".equals(result)) {
+            return reissuedToken;
+        }
+        if (result != null && result.startsWith("GRACE:")) {
+            return fromJson(result.substring("GRACE:".length()));
+        }
+        if ("REUSE_DETECTED".equals(result)) {
+            log.warn("REFRESH_REUSE_DETECTED: family={}", familyId);
+            throw new InvalidateTokenException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
+        }
+        if ("ABSOLUTE_EXPIRED".equals(result)) {
+            throw new ExpiredRefreshTokenException();
+        }
+        throw new InvalidateTokenException();
+    }
+
+    private String toJson(ReissuedToken reissuedToken) {
+        try {
+            return objectMapper.writeValueAsString(reissuedToken);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize rotation response", e);
+        }
+    }
+
+    private ReissuedToken fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, ReissuedToken.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize rotation response", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/utils/JwtUtil.java
+++ b/backend/src/main/java/com/moya/myblogboot/utils/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.moya.myblogboot.utils;
 
 import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.domain.token.AccessTokenClaims;
+import com.moya.myblogboot.domain.token.RefreshTokenClaims;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.domain.token.TokenInfo;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
@@ -14,12 +16,14 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
 public class JwtUtil {
 
     private static final String TOKEN_TYPE_CLAIM = "tokenType";
+    private static final String FAMILY_ID_CLAIM = "familyId";
     private static final String ACCESS_TOKEN_TYPE = "access";
     private static final String REFRESH_TOKEN_TYPE = "refresh";
 
@@ -28,36 +32,62 @@ public class JwtUtil {
     }
 
     public static TokenInfo getTokenInfo(String token, String secret) {
-        Claims claims = parseClaims(token, secret);
-        Long memberPrimaryKey = claims.get("memberPrimaryKey", Long.class);
-        String role = claims.get("role", String.class);
+        AccessTokenClaims claims = parseAccessToken(token, secret);
         return TokenInfo.builder()
-                .memberPrimaryKey(memberPrimaryKey)
-                .role(role)
+                .memberPrimaryKey(claims.memberPrimaryKey())
+                .role(claims.role())
                 .build();
     }
 
+    public static AccessTokenClaims parseAccessToken(String token, String secret) {
+        try {
+            Claims claims = parseClaims(token, secret);
+            validateTokenType(claims, ACCESS_TOKEN_TYPE);
+            Long memberPrimaryKey = claims.get("memberPrimaryKey", Long.class);
+            String role = claims.get("role", String.class);
+            return new AccessTokenClaims(memberPrimaryKey, role);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        }
+    }
+
+    public static RefreshTokenClaims parseRefreshToken(String token, String secret) {
+        try {
+            Claims claims = parseClaims(token, secret);
+            validateTokenType(claims, REFRESH_TOKEN_TYPE);
+            Long memberPrimaryKey = claims.get("memberPrimaryKey", Long.class);
+            String role = claims.get("role", String.class);
+            String jti = claims.getId();
+            String familyId = claims.get(FAMILY_ID_CLAIM, String.class);
+            if (jti == null || jti.isBlank() || familyId == null || familyId.isBlank()) {
+                throw new InvalidateTokenException();
+            }
+            return new RefreshTokenClaims(memberPrimaryKey, role, jti, familyId);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        }
+    }
+
     public static void validateAccessToken(String token, String secret) {
-        validateTokenType(token, secret, ACCESS_TOKEN_TYPE);
+        try {
+            validateTokenType(parseClaims(token, secret), ACCESS_TOKEN_TYPE);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        }
     }
 
     public static void validateRefreshToken(String token, String secret) {
-        validateTokenType(token, secret, REFRESH_TOKEN_TYPE);
-    }
-
-    private static void validateTokenType(String token, String secret, String expectedTokenType) {
         try {
-            Claims claims = parseClaims(token, secret);
-            String tokenType = claims.get(TOKEN_TYPE_CLAIM, String.class);
-            if (!expectedTokenType.equals(tokenType)) {
-                throw new InvalidateTokenException();
-            }
+            validateTokenType(parseClaims(token, secret), REFRESH_TOKEN_TYPE);
         } catch (ExpiredJwtException e) {
             throw new ExpiredTokenException();
-        } catch (SecurityException e) {
-            throw new SecurityException("Invalid token.", e);
-        } catch (MalformedJwtException e) {
-            throw new MalformedJwtException("Malformed token.", e);
+        }
+    }
+
+    private static void validateTokenType(Claims claims, String expectedTokenType) {
+        String tokenType = claims.get(TOKEN_TYPE_CLAIM, String.class);
+        if (!expectedTokenType.equals(tokenType)) {
+            throw new InvalidateTokenException();
         }
     }
 
@@ -71,19 +101,37 @@ public class JwtUtil {
 
     public static Token createToken(Admin admin, Long accessTokenExpiration,
                                     Long refreshTokenExpiration, String secret) {
-        String accessToken = jwtBuild(admin.getId(), "ROLE_ADMIN", accessTokenExpiration, ACCESS_TOKEN_TYPE, secret);
-        String refreshToken = jwtBuild(admin.getId(), "ROLE_ADMIN", refreshTokenExpiration, REFRESH_TOKEN_TYPE, secret);
+        String accessToken = buildAccess(admin.getId(), "ROLE_ADMIN", accessTokenExpiration, secret);
+        String refreshToken = buildRefresh(admin.getId(), "ROLE_ADMIN", UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), refreshTokenExpiration, secret);
         return Token.builder()
                 .access_token(accessToken)
                 .refresh_token(refreshToken)
                 .build();
     }
 
-    private static String jwtBuild(Long memberPrimaryKey, String role, Long expiration, String tokenType, String secret) {
-        return Jwts.builder()
+    public static String buildAccess(Long memberPrimaryKey, String role, Long expirationMs, String secret) {
+        return jwtBuild(memberPrimaryKey, role, expirationMs, ACCESS_TOKEN_TYPE, null, null, secret);
+    }
+
+    public static String buildRefresh(Long memberPrimaryKey, String role, String jti, String familyId,
+                                      long expirationMs, String secret) {
+        return jwtBuild(memberPrimaryKey, role, expirationMs, REFRESH_TOKEN_TYPE, jti, familyId, secret);
+    }
+
+    private static String jwtBuild(Long memberPrimaryKey, String role, Long expiration, String tokenType,
+                                   String jti, String familyId, String secret) {
+        JwtBuilder builder = Jwts.builder()
                 .claim("memberPrimaryKey", memberPrimaryKey)
                 .claim("role", role)
-                .claim(TOKEN_TYPE_CLAIM, tokenType)
+                .claim(TOKEN_TYPE_CLAIM, tokenType);
+        if (jti != null) {
+            builder.id(jti);
+        }
+        if (familyId != null) {
+            builder.claim(FAMILY_ID_CLAIM, familyId);
+        }
+        return builder
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(getSigningKey(secret))
@@ -91,6 +139,6 @@ public class JwtUtil {
     }
 
     public static String reissuingToken(TokenInfo tokenInfo, Long accessTokenExpiration, String secret) {
-        return jwtBuild(tokenInfo.getMemberPrimaryKey(), tokenInfo.getRole(), accessTokenExpiration, ACCESS_TOKEN_TYPE, secret);
+        return buildAccess(tokenInfo.getMemberPrimaryKey(), tokenInfo.getRole(), accessTokenExpiration, secret);
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -29,6 +29,8 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: 600000
   refresh-token-expiration: 1209600000
+  absolute-lifetime: ${JWT_ABSOLUTE_LIFETIME:2592000000}
+  grace-window-ms: ${JWT_GRACE_WINDOW_MS:10000}
 
 # Visitor HMAC
 visitor:

--- a/backend/src/main/resources/scripts/refresh-token-rotate.lua
+++ b/backend/src/main/resources/scripts/refresh-token-rotate.lua
@@ -1,0 +1,61 @@
+local function to_hash(items)
+    local result = {}
+    for i = 1, #items, 2 do
+        result[items[i]] = items[i + 1]
+    end
+    return result
+end
+
+local newJti = ARGV[1]
+local nowIso = ARGV[2]
+local refreshTtlSeconds = tonumber(ARGV[3])
+local graceWindowSeconds = tonumber(ARGV[4])
+local rotationResponseJson = ARGV[5]
+local oldJti = ARGV[6]
+
+local family = redis.call('HGETALL', KEYS[1])
+if #family == 0 then
+    return 'NOT_FOUND'
+end
+
+local f = to_hash(family)
+if f.revoked == 'true' then
+    return 'REVOKED'
+end
+
+if nowIso >= f.absoluteExpiry then
+    redis.call('HSET', KEYS[1], 'revoked', 'true', 'revokedAt', nowIso, 'reason', 'ABSOLUTE_EXPIRED')
+    return 'ABSOLUTE_EXPIRED'
+end
+
+local token = redis.call('HGETALL', KEYS[2])
+if #token == 0 then
+    redis.call('HSET', KEYS[1], 'revoked', 'true', 'revokedAt', nowIso, 'reason', 'REUSE_DETECTED')
+    return 'NOT_FOUND'
+end
+
+local t = to_hash(token)
+if t.status == 'REVOKED' then
+    return 'REVOKED'
+end
+
+if t.status == 'ROTATED' then
+    local cached = redis.call('GET', KEYS[4])
+    if cached then
+        return 'GRACE:' .. cached
+    end
+    redis.call('HSET', KEYS[1], 'revoked', 'true', 'revokedAt', nowIso, 'reason', 'REUSE_DETECTED')
+    return 'REUSE_DETECTED'
+end
+
+redis.call('HSET', KEYS[3],
+        'status', 'ACTIVE',
+        'issuedAt', nowIso,
+        'parentJti', oldJti,
+        'nextJti', '')
+redis.call('EXPIRE', KEYS[3], refreshTtlSeconds)
+
+redis.call('HSET', KEYS[2], 'status', 'ROTATED', 'nextJti', newJti)
+redis.call('SET', KEYS[4], rotationResponseJson, 'EX', graceWindowSeconds)
+
+return 'OK'

--- a/backend/src/test/java/com/moya/myblogboot/repository/RefreshTokenRedisRepositoryTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/repository/RefreshTokenRedisRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.moya.myblogboot.repository;
+
+import com.moya.myblogboot.AbstractContainerBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.moya.myblogboot.domain.keys.RedisKey.REFRESH_FAMILY_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.REFRESH_TOKEN_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RefreshTokenRedisRepositoryTest extends AbstractContainerBaseTest {
+
+    @Autowired
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Autowired
+    @Qualifier("refreshTokenRedisTemplate")
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    @DisplayName("ACTIVE refresh token rotates atomically")
+    void rotateActiveToken() {
+        String familyId = UUID.randomUUID().toString();
+        String oldJti = UUID.randomUUID().toString();
+        String newJti = UUID.randomUUID().toString();
+        Instant now = Instant.now();
+        refreshTokenRedisRepository.saveInitialToken(
+                familyId,
+                oldJti,
+                1L,
+                now,
+                now.plus(Duration.ofDays(30)),
+                Duration.ofDays(60),
+                Duration.ofDays(14)
+        );
+
+        String result = refreshTokenRedisRepository.rotate(
+                familyId,
+                oldJti,
+                newJti,
+                now.plusSeconds(1),
+                Duration.ofDays(14),
+                Duration.ofSeconds(10),
+                "{\"accessToken\":\"access\",\"refreshToken\":\"refresh\"}"
+        );
+
+        assertThat(result).isEqualTo("OK");
+        assertThat(redisTemplate.opsForHash().get(tokenKey(familyId, oldJti), "status")).isEqualTo("ROTATED");
+        assertThat(redisTemplate.opsForHash().get(tokenKey(familyId, oldJti), "nextJti")).isEqualTo(newJti);
+        assertThat(redisTemplate.opsForHash().get(tokenKey(familyId, newJti), "status")).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("ROTATED refresh token returns cached rotation response during grace window")
+    void rotatedTokenReturnsGraceResponse() {
+        String familyId = UUID.randomUUID().toString();
+        String oldJti = UUID.randomUUID().toString();
+        String newJti = UUID.randomUUID().toString();
+        Instant now = Instant.now();
+        String responseJson = "{\"accessToken\":\"access\",\"refreshToken\":\"refresh\"}";
+        refreshTokenRedisRepository.saveInitialToken(
+                familyId,
+                oldJti,
+                1L,
+                now,
+                now.plus(Duration.ofDays(30)),
+                Duration.ofDays(60),
+                Duration.ofDays(14)
+        );
+
+        refreshTokenRedisRepository.rotate(familyId, oldJti, newJti, now.plusSeconds(1),
+                Duration.ofDays(14), Duration.ofSeconds(10), responseJson);
+        String result = refreshTokenRedisRepository.rotate(familyId, oldJti, UUID.randomUUID().toString(),
+                now.plusSeconds(2), Duration.ofDays(14), Duration.ofSeconds(10), "ignored");
+
+        assertThat(result).isEqualTo("GRACE:" + responseJson);
+        assertThat(redisTemplate.opsForHash().get(familyKey(familyId), "revoked")).isEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("Missing token record revokes family")
+    void missingTokenRecordRevokesFamily() {
+        String familyId = UUID.randomUUID().toString();
+        String oldJti = UUID.randomUUID().toString();
+        Instant now = Instant.now();
+        refreshTokenRedisRepository.saveInitialToken(
+                familyId,
+                UUID.randomUUID().toString(),
+                1L,
+                now,
+                now.plus(Duration.ofDays(30)),
+                Duration.ofDays(60),
+                Duration.ofDays(14)
+        );
+
+        String result = refreshTokenRedisRepository.rotate(familyId, oldJti, UUID.randomUUID().toString(),
+                now.plusSeconds(1), Duration.ofDays(14), Duration.ofSeconds(10), "{}");
+
+        assertThat(result).isEqualTo("NOT_FOUND");
+        assertThat(redisTemplate.opsForHash().get(familyKey(familyId), "revoked")).isEqualTo("true");
+        assertThat(redisTemplate.opsForHash().get(familyKey(familyId), "reason")).isEqualTo("REUSE_DETECTED");
+    }
+
+    private String familyKey(String familyId) {
+        return String.format(REFRESH_FAMILY_KEY, familyId);
+    }
+
+    private String tokenKey(String familyId, String jti) {
+        return String.format(REFRESH_TOKEN_KEY, familyId, jti);
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
@@ -3,6 +3,7 @@ package com.moya.myblogboot.service.implementation;
 import com.moya.myblogboot.AbstractContainerBaseTest;
 import com.moya.myblogboot.domain.admin.Admin;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
+import com.moya.myblogboot.domain.token.ReissuedToken;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.repository.AdminRepository;
@@ -81,9 +82,10 @@ class AuthServiceImplTest extends AbstractContainerBaseTest {
                 .build();
 
         Token token = authService.adminLogin(loginReqDto);
-        String result = authService.reissuingAccessToken(token.getRefresh_token());
+        ReissuedToken result = authService.reissuingAccessToken(token.getRefresh_token());
 
-        assertTrue(result instanceof String);
+        assertNotNull(result.accessToken());
+        assertNotNull(result.refreshToken());
     }
 
     @Test

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
@@ -5,6 +5,7 @@ import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.repository.AdminRepository;
+import com.moya.myblogboot.service.RefreshTokenService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,11 +26,13 @@ class AuthServiceImplUnitTest {
     private AdminRepository adminRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @Test
     @DisplayName("Login failures use the same error code")
     void adminLoginFailureUsesSameErrorCode() {
-        AuthServiceImpl authService = new AuthServiceImpl(adminRepository, passwordEncoder);
+        AuthServiceImpl authService = new AuthServiceImpl(adminRepository, passwordEncoder, refreshTokenService);
         LoginReqDto notExistsUsername = LoginReqDto.builder()
                 .username("notExists")
                 .password("testPassword")

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImplTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImplTest.java
@@ -1,0 +1,80 @@
+package com.moya.myblogboot.service.implementation;
+
+import com.moya.myblogboot.AbstractContainerBaseTest;
+import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.domain.token.IssuedToken;
+import com.moya.myblogboot.domain.token.RefreshTokenClaims;
+import com.moya.myblogboot.domain.token.ReissuedToken;
+import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.repository.RefreshTokenRedisRepository;
+import com.moya.myblogboot.service.RefreshTokenService;
+import com.moya.myblogboot.utils.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RefreshTokenServiceImplTest extends AbstractContainerBaseTest {
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+    @Autowired
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Test
+    @DisplayName("Login issue creates refresh token with server-side family")
+    void issueOnLogin() {
+        IssuedToken issuedToken = refreshTokenService.issueOnLogin(admin());
+
+        RefreshTokenClaims claims = JwtUtil.parseRefreshToken(issuedToken.refreshToken(), secret);
+
+        assertThat(claims.jti()).isNotBlank();
+        assertThat(claims.familyId()).isNotBlank();
+        assertThat(refreshTokenRedisRepository.findAbsoluteExpiry(claims.familyId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("Refresh token rotates and old token is accepted only within grace window")
+    void rotateWithGraceWindow() {
+        IssuedToken issuedToken = refreshTokenService.issueOnLogin(admin());
+
+        ReissuedToken first = refreshTokenService.rotate(issuedToken.refreshToken());
+        ReissuedToken grace = refreshTokenService.rotate(issuedToken.refreshToken());
+
+        assertThat(first).isEqualTo(grace);
+        assertThat(JwtUtil.parseRefreshToken(first.refreshToken(), secret).jti())
+                .isNotEqualTo(JwtUtil.parseRefreshToken(issuedToken.refreshToken(), secret).jti());
+    }
+
+    @Test
+    @DisplayName("Logout revokes refresh token family")
+    void revokeOnLogout() {
+        IssuedToken issuedToken = refreshTokenService.issueOnLogin(admin());
+        RefreshTokenClaims claims = JwtUtil.parseRefreshToken(issuedToken.refreshToken(), secret);
+
+        refreshTokenService.revokeOnLogout(issuedToken.refreshToken());
+
+        assertThat(refreshTokenRedisRepository.findFamilyReason(claims.familyId())).contains("LOGOUT");
+        assertThatThrownBy(() -> refreshTokenService.rotate(issuedToken.refreshToken()))
+                .isInstanceOf(InvalidateTokenException.class);
+    }
+
+    private Admin admin() {
+        Admin admin = Admin.builder()
+                .username("admin")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+        return admin;
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/utils/JwtUtilTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/utils/JwtUtilTest.java
@@ -2,7 +2,7 @@ package com.moya.myblogboot.utils;
 
 import com.moya.myblogboot.domain.admin.Admin;
 import com.moya.myblogboot.domain.token.Token;
-import com.moya.myblogboot.domain.token.TokenInfo;
+import com.moya.myblogboot.domain.token.RefreshTokenClaims;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,14 +36,27 @@ class JwtUtilTest {
     @DisplayName("Reissued token from refresh token has access token type")
     void reissuingTokenCreatesAccessToken() {
         Token token = createToken();
-        TokenInfo tokenInfo = JwtUtil.getTokenInfo(token.getRefresh_token(), SECRET);
+        RefreshTokenClaims tokenInfo = JwtUtil.parseRefreshToken(token.getRefresh_token(), SECRET);
 
-        String reissuedAccessToken = JwtUtil.reissuingToken(tokenInfo, ACCESS_TOKEN_EXPIRATION, SECRET);
+        String reissuedAccessToken = JwtUtil.buildAccess(tokenInfo.memberPrimaryKey(), tokenInfo.role(),
+                ACCESS_TOKEN_EXPIRATION, SECRET);
 
         assertThatCode(() -> JwtUtil.validateAccessToken(reissuedAccessToken, SECRET))
                 .doesNotThrowAnyException();
         assertThatThrownBy(() -> JwtUtil.validateRefreshToken(reissuedAccessToken, SECRET))
                 .isInstanceOf(InvalidateTokenException.class);
+    }
+
+    @Test
+    @DisplayName("Refresh token has jti and familyId claims")
+    void refreshTokenClaims() {
+        String refreshToken = JwtUtil.buildRefresh(1L, "ROLE_ADMIN", "jti-1", "family-1",
+                REFRESH_TOKEN_EXPIRATION, SECRET);
+
+        RefreshTokenClaims claims = JwtUtil.parseRefreshToken(refreshToken, SECRET);
+
+        org.assertj.core.api.Assertions.assertThat(claims.jti()).isEqualTo("jti-1");
+        org.assertj.core.api.Assertions.assertThat(claims.familyId()).isEqualTo("family-1");
     }
 
     private Token createToken() {

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -53,6 +53,8 @@ jwt:
   secret: ${JWT_SECRET_KEY:test-jwt-secret-key-for-testing-environment-only}
   access-token-expiration: 600000
   refresh-token-expiration: 1209600000
+  absolute-lifetime: 2592000000
+  grace-window-ms: 10000
 
 # Visitor HMAC
 visitor:


### PR DESCRIPTION
## 작업 내용

  Refresh Token을 서버 측 Redis 상태와 연동하고, 재발급 시마다 Refresh Token을 회전하도록 변경했습니다.

  ### Refresh Token Rotation

  - 로그인 시 refresh token family 생성
  - refresh token에 `jti`, `familyId` claim 추가
  - `/api/v1/reissuing-token` 호출 시 새 access token + 새 refresh token 발급
  - 기존 refresh token은 `ROTATED` 상태로 전환
  - 새 refresh token은 HttpOnly cookie로 재설정

  ### Reuse Detection

  - 이미 회전된 refresh token 재사용 감지
  - grace window 내 중복 요청은 동일 rotation response 반환
  - grace window 이후 재사용 시 family 전체 폐기
  - reuse 감지 전용 에러 코드 `REFRESH_TOKEN_REUSE_DETECTED` 추가

  ### Redis 저장 구조

  - `StringRedisTemplate` 전용 빈 추가
  - refresh token 저장소 분리
  - Redis hash tag 기반 key 사용
    - `refresh:{familyId}:family`
    - `refresh:{familyId}:token:{jti}`
    - `refresh:{familyId}:rotation-response:{jti}`
  - Lua script로 rotation 상태 변경을 원자 처리

  ### 인증 흐름 연동

  - `RefreshTokenService` 추가
  - `AuthServiceImpl`이 refresh token 발급/재발급을 위임하도록 변경
  - `AuthController`에서 reissue 성공 시 새 refresh cookie 설정
  - reissue 실패 시 기존 refresh cookie 삭제
  - `/logout`, `/reissuing-token`은 기존 GET 유지 + POST 병행 지원

  ### 설정 추가

  - `jwt.absolute-lifetime`
  - `jwt.grace-window-ms`

  ## 테스트

  추가/수정한 테스트:

  - `JwtUtilTest`
    - refresh token `jti`, `familyId` claim 검증
    - access/refresh token 타입 검증

  - `RefreshTokenRedisRepositoryTest`
    - ACTIVE token rotation
    - grace window response 반환
    - missing token record 시 family revoke

  - `RefreshTokenServiceImplTest`
    - login issue 시 Redis family 생성
    - refresh rotation 및 grace window 검증
    - logout revoke 검증

  - 기존 인증 테스트 갱신
    - `AuthControllerTest`
    - `AuthServiceImplTest`
    - `AuthServiceImplUnitTest`

  ## 영향 범위

  - 기존에 발급된 refresh token은 jti, familyId가 없어 재발급에 사용할 수 없습니다.
  - 배포 후 기존 로그인 사용자는 재로그인이 필요합니다.
  - /api/v1/reissuing-token 응답은 access token body를 유지하되, refresh token cookie가
    새로 설정됩니다.
  - /api/v1/logout, /api/v1/reissuing-token은 POST를 지원하지만 기존 GET도 유지합니다.