### PR TITLE
feat(backend): 로그인 Brute Force 방어 도입

### DIFF
--- a/backend/src/main/java/com/moya/myblogboot/configuration/LoginAttemptConfig.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/LoginAttemptConfig.java
@@ -1,0 +1,9 @@
+package com.moya.myblogboot.configuration;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(LoginAttemptProperties.class)
+public class LoginAttemptConfig {
+}

--- a/backend/src/main/java/com/moya/myblogboot/configuration/LoginAttemptProperties.java
+++ b/backend/src/main/java/com/moya/myblogboot/configuration/LoginAttemptProperties.java
@@ -1,0 +1,20 @@
+package com.moya.myblogboot.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "security.login-attempt")
+public record LoginAttemptProperties(
+        long windowMs,
+        long baseDelayMs,
+        long maxDelayMs,
+        boolean trustedProxy,
+        List<LockStage> lockStages
+) {
+    public record LockStage(
+            int failureCount,
+            long lockMs
+    ) {
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.service.AuthService;
 import com.moya.myblogboot.service.RefreshTokenService;
+import com.moya.myblogboot.utils.ClientIpResolver;
 import com.moya.myblogboot.utils.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,14 +28,16 @@ public class AuthController {
 
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
+    private final ClientIpResolver clientIpResolver;
 
     @Value("${jwt.refresh-token-expiration}")
     private Long refreshTokenExpiration;
 
     @PostMapping("/api/v1/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginReqDto loginReqDto,
+                                        HttpServletRequest request,
                                         HttpServletResponse response) {
-        Token newToken = authService.adminLogin(loginReqDto);
+        Token newToken = authService.adminLogin(loginReqDto, clientIpResolver.resolve(request));
         addRefreshTokenCookie(response, newToken.getRefresh_token());
         return ResponseEntity.ok().body(newToken.getAccess_token());
     }

--- a/backend/src/main/java/com/moya/myblogboot/domain/keys/RedisKey.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/keys/RedisKey.java
@@ -14,4 +14,9 @@ public class RedisKey {
     public static final String REFRESH_FAMILY_KEY = "refresh:{%s}:family";
     public static final String REFRESH_TOKEN_KEY = "refresh:{%s}:token:%s";
     public static final String REFRESH_ROTATION_RESPONSE_KEY = "refresh:{%s}:rotation-response:%s";
+
+    public static final String LOGIN_FAIL_ACCOUNT_KEY = "login:{acct:%s}:fail";
+    public static final String LOGIN_LOCK_ACCOUNT_KEY = "login:{acct:%s}:lock";
+    public static final String LOGIN_FAIL_IP_KEY = "login:{ip:%s}:fail";
+    public static final String LOGIN_LOCK_IP_KEY = "login:{ip:%s}:lock";
 }

--- a/backend/src/main/java/com/moya/myblogboot/domain/login/LoginAttemptResult.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/login/LoginAttemptResult.java
@@ -1,0 +1,8 @@
+package com.moya.myblogboot.domain.login;
+
+public record LoginAttemptResult(
+        int count,
+        long retryAfterSeconds,
+        boolean locked
+) {
+}

--- a/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A006", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A007", "아이디 또는 비밀번호가 일치하지 않습니다."),
     REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "A008", "리프레시 토큰 재사용이 감지되었습니다."),
+    TOO_MANY_LOGIN_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "A009", "로그인 시도가 너무 많습니다. 잠시 후 다시 시도해 주세요."),
 
     // 어드민
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "회원이 존재하지 않습니다."),

--- a/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.moya.myblogboot.exception;
 
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
+import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
 import com.moya.myblogboot.utils.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
@@ -30,6 +32,16 @@ public class GlobalExceptionHandler {
         log.warn("Business exception: {} - {}", errorCode.getCode(), e.getMessage(), e);
         return ResponseEntity
                 .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(TooManyLoginAttemptsException.class)
+    public ResponseEntity<ErrorResponse> handleTooManyLoginAttempts(TooManyLoginAttemptsException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("Too many login attempts: retryAfterSeconds={}", e.getRetryAfterSeconds());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .header(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfterSeconds()))
                 .body(ErrorResponse.of(errorCode));
     }
 

--- a/backend/src/main/java/com/moya/myblogboot/exception/custom/TooManyLoginAttemptsException.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/custom/TooManyLoginAttemptsException.java
@@ -1,0 +1,16 @@
+package com.moya.myblogboot.exception.custom;
+
+import com.moya.myblogboot.exception.BusinessException;
+import com.moya.myblogboot.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TooManyLoginAttemptsException extends BusinessException {
+
+    private final long retryAfterSeconds;
+
+    public TooManyLoginAttemptsException(long retryAfterSeconds) {
+        super(ErrorCode.TOO_MANY_LOGIN_ATTEMPTS);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/repository/LoginAttemptRedisRepository.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/LoginAttemptRedisRepository.java
@@ -1,0 +1,12 @@
+package com.moya.myblogboot.repository;
+
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
+
+public interface LoginAttemptRedisRepository {
+
+    long checkLockTtlMs(String lockKey);
+
+    LoginAttemptResult recordFailure(String failKey, String lockKey);
+
+    void reset(String failKey, String lockKey);
+}

--- a/backend/src/main/java/com/moya/myblogboot/repository/implementation/LoginAttemptRedisRepositoryImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/implementation/LoginAttemptRedisRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.moya.myblogboot.repository.implementation;
+
+import com.moya.myblogboot.configuration.LoginAttemptProperties;
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
+import com.moya.myblogboot.repository.LoginAttemptRedisRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class LoginAttemptRedisRepositoryImpl implements LoginAttemptRedisRepository {
+
+    private static final String CHECK = "CHECK";
+    private static final String FAIL = "FAIL";
+    private static final String RESET = "RESET";
+
+    private final StringRedisTemplate redisTemplate;
+    private final LoginAttemptProperties properties;
+    private final DefaultRedisScript<String> script;
+
+    public LoginAttemptRedisRepositoryImpl(
+            @Qualifier("refreshTokenRedisTemplate") StringRedisTemplate redisTemplate,
+            LoginAttemptProperties properties) {
+        this.redisTemplate = redisTemplate;
+        this.properties = properties;
+        this.script = new DefaultRedisScript<>();
+        this.script.setLocation(new ClassPathResource("scripts/login-attempt.lua"));
+        this.script.setResultType(String.class);
+    }
+
+    @Override
+    public long checkLockTtlMs(String lockKey) {
+        String result = redisTemplate.execute(script, List.of(lockKey), CHECK);
+        return parseLong(result);
+    }
+
+    @Override
+    public LoginAttemptResult recordFailure(String failKey, String lockKey) {
+        String result = redisTemplate.execute(
+                script,
+                List.of(failKey, lockKey),
+                FAIL,
+                String.valueOf(properties.windowMs()),
+                lockStagesArg()
+        );
+        String[] parts = result == null ? new String[0] : result.split(":");
+        if (parts.length != 3) {
+            throw new IllegalStateException("Unexpected login attempt Redis result: " + result);
+        }
+        int count = Integer.parseInt(parts[0]);
+        long lockTtlMs = Long.parseLong(parts[1]);
+        boolean locked = "1".equals(parts[2]) || lockTtlMs > 0;
+        return new LoginAttemptResult(count, toRetryAfterSeconds(lockTtlMs), locked);
+    }
+
+    @Override
+    public void reset(String failKey, String lockKey) {
+        redisTemplate.execute(script, List.of(failKey, lockKey), RESET);
+    }
+
+    private String lockStagesArg() {
+        return properties.lockStages().stream()
+                .map(stage -> stage.failureCount() + "=" + stage.lockMs())
+                .collect(Collectors.joining(","));
+    }
+
+    private long parseLong(String value) {
+        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
+    }
+
+    private long toRetryAfterSeconds(long ttlMs) {
+        if (ttlMs <= 0) {
+            return 0;
+        }
+        return (ttlMs + 999) / 1000;
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
@@ -7,7 +7,11 @@ import com.moya.myblogboot.domain.token.ReissuedToken;
 
 public interface AuthService {
 
-    Token adminLogin(LoginReqDto loginReqDto);
+    default Token adminLogin(LoginReqDto loginReqDto) {
+        return adminLogin(loginReqDto, "unknown");
+    }
+
+    Token adminLogin(LoginReqDto loginReqDto, String clientIp);
 
     ReissuedToken reissuingAccessToken(String refreshToken);
 

--- a/backend/src/main/java/com/moya/myblogboot/service/LoginAttemptService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/LoginAttemptService.java
@@ -1,0 +1,14 @@
+package com.moya.myblogboot.service;
+
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
+
+public interface LoginAttemptService {
+
+    void assertNotLocked(String username, String clientIp);
+
+    LoginAttemptResult onFailure(String username, String clientIp);
+
+    void onSuccess(String username, String clientIp);
+
+    void applyProgressiveDelay(int count);
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthCredentialVerifier.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthCredentialVerifier.java
@@ -1,0 +1,35 @@
+package com.moya.myblogboot.service.implementation;
+
+import com.moya.myblogboot.domain.admin.Admin;
+import com.moya.myblogboot.dto.auth.LoginReqDto;
+import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.exception.custom.UnauthorizedException;
+import com.moya.myblogboot.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthCredentialVerifier {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public Admin verify(LoginReqDto loginReqDto) {
+        Admin admin = adminRepository.findByUsername(loginReqDto.getUsername())
+                .orElseThrow(() -> {
+                    log.warn("Admin login failed: username not found");
+                    return new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+                });
+        if (!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword())) {
+            log.warn("Admin login failed: invalid password");
+            throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+        }
+        return admin;
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
@@ -5,48 +5,50 @@ import com.moya.myblogboot.domain.token.AccessTokenClaims;
 import com.moya.myblogboot.domain.token.IssuedToken;
 import com.moya.myblogboot.domain.token.ReissuedToken;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
 import com.moya.myblogboot.domain.token.Token;
 import com.moya.myblogboot.domain.token.TokenInfo;
-import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
-import com.moya.myblogboot.repository.AdminRepository;
 import com.moya.myblogboot.service.AuthService;
+import com.moya.myblogboot.service.LoginAttemptService;
 import com.moya.myblogboot.service.RefreshTokenService;
 import com.moya.myblogboot.utils.JwtUtil;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuthServiceImpl implements AuthService {
 
-    private final AdminRepository adminRepository;
-    private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
+    private final LoginAttemptService loginAttemptService;
+    private final AuthCredentialVerifier authCredentialVerifier;
 
     @Value("${jwt.secret}")
     private String secret;
 
     @Override
-    public Token adminLogin(LoginReqDto loginReqDto) {
-        Admin admin = adminRepository.findByUsername(loginReqDto.getUsername())
-                .orElseThrow(() -> {
-                    log.warn("Admin login failed: username not found");
-                    return new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
-                });
-        if (!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword())) {
-            log.warn("Admin login failed: invalid password");
-            throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+    public Token adminLogin(LoginReqDto loginReqDto, String clientIp) {
+        loginAttemptService.assertNotLocked(loginReqDto.getUsername(), clientIp);
+        Admin admin;
+        try {
+            admin = authCredentialVerifier.verify(loginReqDto);
+        } catch (UnauthorizedException e) {
+            LoginAttemptResult result = loginAttemptService.onFailure(loginReqDto.getUsername(), clientIp);
+            if (result.locked()) {
+                throw new TooManyLoginAttemptsException(result.retryAfterSeconds());
+            }
+            loginAttemptService.applyProgressiveDelay(result.count());
+            throw e;
         }
+        loginAttemptService.onSuccess(loginReqDto.getUsername(), clientIp);
         IssuedToken issuedToken = refreshTokenService.issueOnLogin(admin);
         return Token.builder()
                 .access_token(issuedToken.accessToken())

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/LoginAttemptServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/LoginAttemptServiceImpl.java
@@ -1,0 +1,121 @@
+package com.moya.myblogboot.service.implementation;
+
+import com.moya.myblogboot.configuration.LoginAttemptProperties;
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
+import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
+import com.moya.myblogboot.repository.LoginAttemptRedisRepository;
+import com.moya.myblogboot.service.LoginAttemptService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import static com.moya.myblogboot.domain.keys.RedisKey.LOGIN_FAIL_ACCOUNT_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.LOGIN_FAIL_IP_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.LOGIN_LOCK_ACCOUNT_KEY;
+import static com.moya.myblogboot.domain.keys.RedisKey.LOGIN_LOCK_IP_KEY;
+
+@Service
+@RequiredArgsConstructor
+public class LoginAttemptServiceImpl implements LoginAttemptService {
+
+    private final LoginAttemptRedisRepository loginAttemptRedisRepository;
+    private final LoginAttemptProperties properties;
+
+    @Override
+    public void assertNotLocked(String username, String clientIp) {
+        LoginKeys keys = loginKeys(username, clientIp);
+        long accountTtlMs = loginAttemptRedisRepository.checkLockTtlMs(keys.accountLockKey());
+        long ipTtlMs = loginAttemptRedisRepository.checkLockTtlMs(keys.ipLockKey());
+        long retryAfterMs = Math.max(accountTtlMs, ipTtlMs);
+        if (retryAfterMs > 0) {
+            throw new TooManyLoginAttemptsException(toRetryAfterSeconds(retryAfterMs));
+        }
+    }
+
+    @Override
+    public LoginAttemptResult onFailure(String username, String clientIp) {
+        LoginKeys keys = loginKeys(username, clientIp);
+        LoginAttemptResult accountResult = loginAttemptRedisRepository.recordFailure(
+                keys.accountFailKey(), keys.accountLockKey());
+        LoginAttemptResult ipResult = loginAttemptRedisRepository.recordFailure(
+                keys.ipFailKey(), keys.ipLockKey());
+
+        int count = Math.max(accountResult.count(), ipResult.count());
+        long retryAfterSeconds = Math.max(accountResult.retryAfterSeconds(), ipResult.retryAfterSeconds());
+        boolean locked = accountResult.locked() || ipResult.locked();
+        return new LoginAttemptResult(count, retryAfterSeconds, locked);
+    }
+
+    @Override
+    public void onSuccess(String username, String clientIp) {
+        LoginKeys keys = loginKeys(username, clientIp);
+        loginAttemptRedisRepository.reset(keys.accountFailKey(), keys.accountLockKey());
+        loginAttemptRedisRepository.reset(keys.ipFailKey(), keys.ipLockKey());
+    }
+
+    @Override
+    public void applyProgressiveDelay(int count) {
+        long delayMs = Math.min(
+                multiplySafely(properties.baseDelayMs(), count),
+                properties.maxDelayMs()
+        );
+        if (delayMs <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private LoginKeys loginKeys(String username, String clientIp) {
+        String accountHash = sha256Hex(username);
+        String ipHash = sha256Hex(clientIp);
+        return new LoginKeys(
+                String.format(LOGIN_FAIL_ACCOUNT_KEY, accountHash),
+                String.format(LOGIN_LOCK_ACCOUNT_KEY, accountHash),
+                String.format(LOGIN_FAIL_IP_KEY, ipHash),
+                String.format(LOGIN_LOCK_IP_KEY, ipHash)
+        );
+    }
+
+    private String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private long multiplySafely(long baseDelayMs, int count) {
+        if (count <= 1) {
+            return baseDelayMs;
+        }
+        long result = baseDelayMs;
+        for (int i = 1; i < count; i++) {
+            if (result >= properties.maxDelayMs()) {
+                return properties.maxDelayMs();
+            }
+            result *= 2;
+        }
+        return result;
+    }
+
+    private long toRetryAfterSeconds(long retryAfterMs) {
+        return (retryAfterMs + 999) / 1000;
+    }
+
+    private record LoginKeys(
+            String accountFailKey,
+            String accountLockKey,
+            String ipFailKey,
+            String ipLockKey
+    ) {
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/utils/ClientIpResolver.java
+++ b/backend/src/main/java/com/moya/myblogboot/utils/ClientIpResolver.java
@@ -1,0 +1,30 @@
+package com.moya.myblogboot.utils;
+
+import com.moya.myblogboot.configuration.LoginAttemptProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClientIpResolver {
+
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String UNKNOWN = "unknown";
+
+    private final LoginAttemptProperties properties;
+
+    public String resolve(HttpServletRequest request) {
+        if (properties.trustedProxy()) {
+            String forwardedFor = request.getHeader(X_FORWARDED_FOR);
+            if (forwardedFor != null && !forwardedFor.isBlank()) {
+                String firstIp = forwardedFor.split(",")[0].trim();
+                if (!firstIp.isBlank() && !UNKNOWN.equalsIgnoreCase(firstIp)) {
+                    return firstIp;
+                }
+            }
+        }
+        String remoteAddr = request.getRemoteAddr();
+        return remoteAddr == null || remoteAddr.isBlank() ? UNKNOWN : remoteAddr;
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -55,6 +55,22 @@ revalidate:
     connect-timeout-ms: ${REVALIDATE_CONNECT_TIMEOUT:2000}
     read-timeout-ms: ${REVALIDATE_READ_TIMEOUT:3000}
 
+security:
+  login-attempt:
+    window-ms: ${LOGIN_ATTEMPT_WINDOW_MS:600000}
+    base-delay-ms: ${LOGIN_ATTEMPT_BASE_DELAY_MS:200}
+    max-delay-ms: ${LOGIN_ATTEMPT_MAX_DELAY_MS:2000}
+    trusted-proxy: ${LOGIN_ATTEMPT_TRUSTED_PROXY:false}
+    lock-stages:
+      - failure-count: 5
+        lock-ms: ${LOGIN_ATTEMPT_LOCK_5_MS:60000}
+      - failure-count: 10
+        lock-ms: ${LOGIN_ATTEMPT_LOCK_10_MS:300000}
+      - failure-count: 15
+        lock-ms: ${LOGIN_ATTEMPT_LOCK_15_MS:900000}
+      - failure-count: 20
+        lock-ms: ${LOGIN_ATTEMPT_LOCK_20_MS:3600000}
+
 # Blog metadata (RSS feed)
 app:
   base-url: ${APP_BASE_URL:http://localhost:8080}

--- a/backend/src/main/resources/scripts/login-attempt.lua
+++ b/backend/src/main/resources/scripts/login-attempt.lua
@@ -1,0 +1,44 @@
+local mode = ARGV[1]
+
+if mode == 'CHECK' then
+    local ttl = redis.call('PTTL', KEYS[1])
+    if ttl > 0 then
+        return tostring(ttl)
+    end
+    return '0'
+end
+
+if mode == 'FAIL' then
+    local windowMs = tonumber(ARGV[2])
+    local stages = ARGV[3]
+
+    local count = redis.call('INCR', KEYS[1])
+    redis.call('PEXPIRE', KEYS[1], windowMs)
+
+    local existingLockTtl = redis.call('PTTL', KEYS[2])
+    if existingLockTtl > 0 then
+        return tostring(count) .. ':' .. tostring(existingLockTtl) .. ':0'
+    end
+
+    local lockTtlMs = 0
+    for failureCount, lockMs in string.gmatch(stages, '(%d+)=(%d+)') do
+        if count == tonumber(failureCount) then
+            lockTtlMs = tonumber(lockMs)
+            break
+        end
+    end
+
+    if lockTtlMs > 0 then
+        redis.call('SET', KEYS[2], '1', 'PX', lockTtlMs)
+        return tostring(count) .. ':' .. tostring(lockTtlMs) .. ':1'
+    end
+
+    return tostring(count) .. ':0:0'
+end
+
+if mode == 'RESET' then
+    redis.call('DEL', KEYS[1], KEYS[2])
+    return 'OK'
+end
+
+return 'UNKNOWN_MODE'

--- a/backend/src/test/java/com/moya/myblogboot/RedisTestCleaner.java
+++ b/backend/src/test/java/com/moya/myblogboot/RedisTestCleaner.java
@@ -1,0 +1,28 @@
+package com.moya.myblogboot;
+
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RedisTestCleaner {
+
+    private RedisTestCleaner() {
+    }
+
+    public static void deleteLoginAttemptKeys(StringRedisTemplate redisTemplate) {
+        ScanOptions options = ScanOptions.scanOptions()
+                .match("login:*")
+                .count(100)
+                .build();
+        List<String> keys = new ArrayList<>();
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            cursor.forEachRemaining(keys::add);
+        }
+        if (!keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.moya.myblogboot.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moya.myblogboot.AbstractContainerBaseTest;
+import com.moya.myblogboot.RedisTestCleaner;
 import com.moya.myblogboot.config.RestDocsConfiguration;
 import com.moya.myblogboot.domain.admin.Admin;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
@@ -18,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -59,6 +61,8 @@ class AuthControllerTest extends AbstractContainerBaseTest {
     private RestDocumentationResultHandler restDocs;
     @Autowired
     private ObjectMapper objectMapper;
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentationContextProvider) {
@@ -71,6 +75,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 
     @BeforeEach
     void before() {
+        RedisTestCleaner.deleteLoginAttemptKeys(stringRedisTemplate);
         Admin admin = Admin.builder()
                 .username("testuser")
                 .password(passwordEncoder.encode("testPassword"))
@@ -178,6 +183,31 @@ class AuthControllerTest extends AbstractContainerBaseTest {
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 5회째부터 429와 Retry-After를 반환한다")
+    void loginBruteForceProtection() throws Exception {
+        LoginReqDto requestBody = LoginReqDto.builder()
+                .username("testuser")
+                .password("wrongPassword")
+                .build();
+
+        for (int i = 0; i < 4; i++) {
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("A007"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.RETRY_AFTER));
+        }
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestBody)))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("A009"))
+                .andExpect(MockMvcResultMatchers.header().exists(HttpHeaders.RETRY_AFTER));
     }
 
     @Test

--- a/backend/src/test/java/com/moya/myblogboot/service/LoginAttemptServiceTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/LoginAttemptServiceTest.java
@@ -1,0 +1,104 @@
+package com.moya.myblogboot.service;
+
+import com.moya.myblogboot.AbstractContainerBaseTest;
+import com.moya.myblogboot.RedisTestCleaner;
+import com.moya.myblogboot.domain.login.LoginAttemptResult;
+import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = {
+        "security.login-attempt.window-ms=500",
+        "security.login-attempt.base-delay-ms=1",
+        "security.login-attempt.max-delay-ms=2"
+})
+@ActiveProfiles("test")
+class LoginAttemptServiceTest extends AbstractContainerBaseTest {
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeEach
+    void beforeEach() {
+        RedisTestCleaner.deleteLoginAttemptKeys(stringRedisTemplate);
+    }
+
+    @Test
+    @DisplayName("5번째 로그인 실패부터 잠금 처리한다")
+    void lockOnFifthFailure() {
+        String username = "testuser";
+        String clientIp = "127.0.0.1";
+
+        for (int i = 1; i <= 4; i++) {
+            LoginAttemptResult result = loginAttemptService.onFailure(username, clientIp);
+            assertThat(result.count()).isEqualTo(i);
+            assertThat(result.locked()).isFalse();
+        }
+
+        LoginAttemptResult result = loginAttemptService.onFailure(username, clientIp);
+
+        assertThat(result.count()).isEqualTo(5);
+        assertThat(result.locked()).isTrue();
+        assertThat(result.retryAfterSeconds()).isBetween(1L, 60L);
+        assertThatThrownBy(() -> loginAttemptService.assertNotLocked(username, clientIp))
+                .isInstanceOf(TooManyLoginAttemptsException.class);
+    }
+
+    @Test
+    @DisplayName("실패 카운터 TTL은 마지막 실패 기준으로 갱신된다")
+    void slidingWindowRefreshesTtl() throws Exception {
+        String username = "slidingUser";
+        String clientIp = "127.0.0.2";
+        String failKey = "login:{acct:" + sha256Hex(username) + "}:fail";
+
+        loginAttemptService.onFailure(username, clientIp);
+        Thread.sleep(250);
+        loginAttemptService.onFailure(username, clientIp);
+
+        Long ttlMs = stringRedisTemplate.getExpire(failKey, TimeUnit.MILLISECONDS);
+        assertThat(ttlMs).isNotNull();
+        assertThat(ttlMs).isGreaterThan(350L);
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 계정과 IP 카운터 및 잠금 키를 삭제한다")
+    void successResetsCountersAndLocks() {
+        String username = "resetUser";
+        String clientIp = "127.0.0.3";
+
+        for (int i = 0; i < 5; i++) {
+            loginAttemptService.onFailure(username, clientIp);
+        }
+        loginAttemptService.onSuccess(username, clientIp);
+
+        assertThat(stringRedisTemplate.hasKey("login:{acct:" + sha256Hex(username) + "}:fail")).isFalse();
+        assertThat(stringRedisTemplate.hasKey("login:{acct:" + sha256Hex(username) + "}:lock")).isFalse();
+        assertThat(stringRedisTemplate.hasKey("login:{ip:" + sha256Hex(clientIp) + "}:fail")).isFalse();
+        assertThat(stringRedisTemplate.hasKey("login:{ip:" + sha256Hex(clientIp) + "}:lock")).isFalse();
+    }
+
+    private String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplUnitTest.java
@@ -5,6 +5,7 @@ import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.repository.AdminRepository;
+import com.moya.myblogboot.service.LoginAttemptService;
 import com.moya.myblogboot.service.RefreshTokenService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,11 +29,14 @@ class AuthServiceImplUnitTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private RefreshTokenService refreshTokenService;
+    @Mock
+    private LoginAttemptService loginAttemptService;
 
     @Test
     @DisplayName("Login failures use the same error code")
     void adminLoginFailureUsesSameErrorCode() {
-        AuthServiceImpl authService = new AuthServiceImpl(adminRepository, passwordEncoder, refreshTokenService);
+        AuthCredentialVerifier authCredentialVerifier = new AuthCredentialVerifier(adminRepository, passwordEncoder);
+        AuthServiceImpl authService = new AuthServiceImpl(refreshTokenService, loginAttemptService, authCredentialVerifier);
         LoginReqDto notExistsUsername = LoginReqDto.builder()
                 .username("notExists")
                 .password("testPassword")

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -33,6 +33,11 @@ revalidate:
   webhook:
     enabled: false
 
+security:
+  login-attempt:
+    base-delay-ms: 1
+    max-delay-ms: 2
+
 ## Logging
 logging:
   level:


### PR DESCRIPTION
## 개요

  관리자 로그인 API(`POST /api/v1/login`)에 Brute Force 방어를 추가했습니다.

  Redis + Lua 기반으로 계정/클라이언트 IP별 실패 횟수를 카운팅하고, 누적 실패 단계에 따
  라 임시 잠금을 적용합니다. 1~4회 실패는 기존과 동일하게 `401 A007`을 반환하고, 5회째
  실패부터는 `429 A009`와 `Retry-After` 헤더를 반환합니다.

  ## 주요 변경

  - 로그인 실패 카운팅 및 잠금 처리 추가
    - 계정 기준 카운터
    - IP 기준 카운터
    - 둘 중 하나라도 잠금 상태면 로그인 차단
  - Redis Lua 스크립트 추가
    - `CHECK`, `FAIL`, `RESET` 모드 지원
    - account/ip 키 그룹을 분리 호출해 Redis Cluster `CROSSSLOT` 회피
    - 실패 카운터 TTL은 매 실패마다 갱신해 sliding window로 동작
  - Redis 키 세그먼트에 원문 username/IP 대신 `sha256Hex` 사용
  - `TooManyLoginAttemptsException` 및 전용 예외 핸들러 추가
    - `429 Too Many Requests`
    - `Retry-After` 헤더 포함
  - `AuthCredentialVerifier` 분리
    - DB 자격 검증만 트랜잭션 안에서 수행
    - Redis I/O 및 점진 지연은 트랜잭션 밖에서 수행
  - 로그인 시도 관련 설정 추가
    - `security.login-attempt.*`
  - 테스트 추가 및 보강
    - `LoginAttemptServiceTest`
    - `AuthControllerTest`
    - Redis 테스트 키 정리 helper 추가

  ## 응답 정책

  - 1~4회 실패: `401`, `code=A007`
  - 5회째 실패: `429`, `code=A009`, `Retry-After` 헤더
  - 잠금 중 올바른 자격 증명으로 요청해도 `429`
  - 로그인 성공 시 계정/IP 실패 카운터 및 잠금 키 초기화