### PR TITLE
refactor(auth): 인증 감사와 토큰 계약 정리

### DIFF
--- a/backend/docs/260513_auth-controller-senior-review.md
+++ b/backend/docs/260513_auth-controller-senior-review.md
@@ -1,0 +1,271 @@
+# AuthController & 인증 도메인 시니어 리뷰
+
+> 작성일: 2026-05-13
+> 리뷰 대상: `AuthController`, `AuthServiceImpl`, `JwtUtil`, `JwtFilter`, `CookieUtil`, `LoginReqDto`, `Token`/`TokenInfo`, `ShouldNotFilterPath`, `GlobalExceptionHandler`(인증 관련), `WebSecurityConfig`, `application.yaml`
+> 분류: P0 (즉시 수정) / P1 (보안 강화) / P2 (품질 개선)
+>
+> **진행 상황 갱신: 2026-05-25** — 잔여 P2(Q-3·Q-4·Q-6 접두사 노출·Q-7 재확인·Q-8) **완료·검증**. 실제 코드 대조 + `AuthControllerTest` BUILD SUCCESSFUL로 검증(커밋 메시지 아님). 구현·검증 상세: 계획서 `260524_auth-p2-remaining-plan.md` §7
+> 이전 갱신: 2026-05-22
+
+---
+
+## 📊 진행 상황 요약 (2026-05-25 기준)
+
+범례: ✅ 완료 · 🟡 부분 완료 · ❌ 미착수
+
+| 항목 | 상태 | 근거 커밋 / 비고 |
+|---|---|---|
+| **B-1** 토큰 검증 메서드 시멘틱 정정 | ✅ 완료 | `a7c150f` — `isTokenValid` / `parseAccessToken` 분리, dead code 제거 |
+| **B-2** RefreshToken 쿠키명 오타 | ✅ 완료 | `a2d6ae8` — `CookieName.REFRESH_TOKEN_COOKIE` 상수 사용 |
+| **B-3** RefreshToken 서버측 회전/재사용 탐지 | ✅ 완료 | `693af43` — Redis 화이트리스트 + jti/family + Lua 원자 회전 |
+| **B-4** Access/Refresh 토큰 구분 claim | ✅ 완료 | `26c3850` — `tokenType` claim + `validateTokenType` 강제 |
+| **S-1** User Enumeration | ✅ 완료 | `97844fc` — `INVALID_CREDENTIALS` 단일화, 상세 사유는 서버 로그만 |
+| **S-2** 로그인 Brute Force 방지 | ✅ 완료 | `6eaeb25` — Redis+Lua 계정/IP 이중 키, 점진 지연·단계 잠금, 429+`Retry-After`(A009) |
+| **S-3** 표준 에러 응답 (EntryPoint) | ✅ 완료 | `97844fc` — `SecurityErrorResponseWriter` + EntryPoint/AccessDeniedHandler, JwtFilter `sendError` 제거 |
+| **S-4** Access Token raw string 반환 | ✅ 완료 | Access Token HttpOnly 쿠키 전환 + 메타 JSON 응답 (계획서 `260519_cookie-response-policy-plan.md`) |
+| **S-5** JWT Secret 길이 검증 | ✅ 완료 | 32byte fail-fast (Q-1에서 `JwtSecretValidator` → `JwtProperties` compact 생성자로 이전, 메시지 포맷 유지) |
+| **S-6** Refresh 쿠키 maxAge 미지정 | ✅ 완료 | `addRefreshTokenCookie`에 `refreshTokenExpiration/1000` 적용 |
+| **S-7** 쿠키 SameSite/Secure/도메인 정책 | ✅ 완료 | `CookieProperties`/`CookieFactory` 외부화, `application-{dev,prod}.yaml` `security.cookie` 환경 분기 |
+| **S-8** `/logout` GET | ✅ 완료 | `logout`·`reissuing-token` POST 전용화 (계획서에서 S-4와 함께 마감) |
+| **Q-1** JwtUtil 정적 + @Component | ✅ 완료 | `JwtTokenProvider` 빈 신설(`SecretKey` 1회 캐싱) + `JwtProperties`(@ConfigurationProperties) SSOT. `JwtUtil`·`JwtSecretValidator` 삭제, 운영 코드 `@Value("${jwt.secret}")` 0건 |
+| **Q-2** Token DTO snake_case | ✅ 완료 | `Token` 삭제 → `IssuedToken` record 통합. snake_case 게터 0건 |
+| **Q-3** LoginReqDto 메시지 불일치 | ✅ 완료 | 거짓 특수문자 안내 제거, 민감 필드 `rejectedValue` 응답 마스킹 |
+| **Q-4** `/token-validation` 효용 | ✅ 완료 | 미사용 공개 엔드포인트와 `AuthService.isTokenValid` 제거, RestDocs 섹션 삭제 |
+| **Q-5** JWT 표준 claim | ✅ 완료 | access에 `jti`/`iss`/`aud`/`nbf` 부착 + parse 강제검증(`requireIssuer`/`requireAudience`, `clockSkewSeconds(30)`). jjwt 예외 전부 도메인 예외로 매핑 (raw 누출 차단) |
+| **Q-6** role `"ROLE_ADMIN"` 하드코딩 | ✅ 완료 | 내부 authority는 `ROLE_ADMIN` 유지, `/token-role` 외부 응답은 `ADMIN`으로 변환. 프론트 `RoleGate` 전이 호환 반영 |
+| **Q-7** Bearer 파싱 중복 | ✅ 완료 | `TokenResolver` 단일 경로로 쿠키 토큰 해석 통합 확인. 코드 변경 없음 |
+| **Q-8** 인증 시도 audit 로그 | ✅ 완료 | `AUDIT` logger로 로그인/로그아웃/재발급/잠금/reuse 이벤트에 IP·UA·결과 기록 |
+
+**요약**: P0 4건 전부 완료 ✅. **P1 8건 전부 완료 ✅** (S-1~S-8). **P2 전부 완료 ✅**.
+
+**다음 권장 작업**: static docs 재생성 결과와 배포 순서 확인. Q-6은 프론트 전이 호환이 먼저 반영되어 있으므로 백엔드 `/token-role` → `ADMIN` 전환과 함께 배포 가능.
+
+---
+
+## 🔴 P0 — 명백한 버그 / 보안 결함
+
+### ✅ B-1. `tokenIsExpired()` 메서드명과 반환 의미가 정반대 — **완료 (`a7c150f`)**
+
+**위치**: `AuthServiceImpl.java:63-71`
+
+```java
+public boolean tokenIsExpired(String token) {
+    try { JwtUtil.validateToken(token, secret); return true; }   // 유효하면 true ?!
+    catch (Exception e) { return false; }
+}
+```
+
+- 이름은 "expired"인데 **유효할 때 true**. `/api/v1/token-validation` 응답 의미가 클라이언트와 어긋남.
+- `getTokenInfo()`에서 호출 결과를 **사용하지도 않음** (`tokenIsExpired(token);`만 호출) → dead code.
+- `catch (Exception e)`로 광범위하게 잡아 `ExpiredTokenException`을 삼킴 → "만료"와 "서명 위조" 구분 불가.
+
+**권장**: `isTokenValid` / `assertNotExpired`로 시멘틱 분리. `getTokenInfo`에서는 사전 호출 제거 (parser가 어차피 만료를 던짐).
+
+---
+
+### ✅ B-2. RefreshToken 만료 핸들러의 쿠키명 하드코딩 오타 — **완료 (`a2d6ae8`)**
+
+**위치**: `GlobalExceptionHandler.java:39`
+
+```java
+Cookie refreshTokenCookie = CookieUtil.findCookie(request, "refresh_token_key");
+```
+
+- 실제 쿠키명은 `CookieName.REFRESH_TOKEN_COOKIE = "refresh_token"` (`CookieName.java:5`).
+- 이 분기는 **절대 매치되지 않음** → 만료된 refresh_token이 클라이언트에 그대로 남아 다음 요청에서 또 401.
+
+**수정**: `CookieUtil.findCookie(request, CookieName.REFRESH_TOKEN_COOKIE)`. 1줄 패치.
+
+---
+
+### ✅ B-3. RefreshToken이 서버 측에 저장되지 않음 — **완료 (`693af43`)**
+
+- `JwtUtil.createToken`이 refresh를 단순히 만료 길게 잡은 JWT로만 발급. DB/Redis 화이트리스트 없음.
+- `/api/v1/logout`은 클라이언트 쿠키만 비움 → 서버는 토큰 살아있는지 모름.
+- 탈취된 refresh로 `/api/v1/reissuing-token` 무한 호출 → 14일치 access token 발급 가능.
+
+**표준 패턴**: Refresh Rotation + Reuse Detection (Redis에 `jti` 또는 해시 저장, 사용 시 회전·기존 폐기, 동일 jti 재사용 감지 시 전체 family 폐기).
+
+---
+
+### ✅ B-4. AccessToken ↔ RefreshToken 구분 claim이 없음 (Token Confusion) — **완료 (`26c3850`)**
+
+**위치**: `JwtUtil.java:54-62`
+
+```java
+String accessToken  = jwtBuild(admin.getId(), "ROLE_ADMIN", accessTokenExpiration, secret);
+String refreshToken = jwtBuild(admin.getId(), "ROLE_ADMIN", refreshTokenExpiration, secret);
+```
+
+- 두 토큰의 차이는 **만료시간뿐**. `typ`/`tokenType` claim 없음.
+- access token을 refresh 쿠키로 보내거나 그 역도 JwtFilter가 그대로 통과시킴. `/api/v1/reissuing-token`은 access token으로도 호출 가능.
+
+**수정**: `typ:"access"|"refresh"` claim 강제 + validate 시 검사. 가능하면 secret 자체를 분리(`jwt.access-secret`, `jwt.refresh-secret`).
+
+---
+
+## 🟠 P1 — 보안/설계상 보완 필요
+
+### ✅ S-1. User Enumeration — 로그인 실패가 두 코드로 갈림 — **완료 (`97844fc`)**
+
+**위치**: `AuthServiceImpl.java:40-44` → `MEMBER_NOT_FOUND` vs `INVALID_PASSWORD`
+
+- 공격자가 어떤 username이 존재하는지 응답코드로 식별 가능.
+- **수정**: 로그인 실패는 한 종류(`UNAUTHORIZED` 또는 `INVALID_CREDENTIALS`)로 통일. 서버 로그에만 상세 사유 남길 것.
+
+### ✅ S-2. 로그인 Brute Force 방지 장치 없음 — **완료 (`6eaeb25`)**
+
+> 구현: 계획서 `260517_brute-force-protection-plan.md` 기반. Redis+Lua 원자 연산, 계정/IP
+> 이중 키(SHA-256 세그먼트), sliding 윈도우 카운트, 점진 지연 + 단계별 임시 잠금,
+> `TooManyLoginAttemptsException` → 전용 핸들러로 429 + `Retry-After`(`A009`).
+> 트랜잭션 경계 밖에서 지연/Redis I/O 수행.
+
+- 어드민 단일 계정이라 더 치명적. IP+계정별 슬라이딩 윈도우 시도 카운트(Redis) + 점진적 지연(또는 임시 잠금) 권장.
+- Bucket4j 도입이 가장 간단.
+
+### ✅ S-3. JwtFilter가 직접 `response.sendError(...)` — 표준 에러 응답 우회 — **완료 (`97844fc`)**
+
+**위치**: `JwtFilter.java:46, 53-60`
+
+- `GlobalExceptionHandler`를 거치지 않고 톰캣 기본 에러 페이지(또는 빈 401)가 나감 → 응답 포맷이 `ErrorResponse`와 달라 프론트가 분기 어려움.
+- 헤더가 없으면 통과(`chain.doFilter`), 헤더는 있는데 비면 401 → 비일관.
+- **수정**: `AuthenticationEntryPoint` 등록 후 `ErrorResponse` JSON으로 통일.
+
+### ✅ S-4. Access Token을 응답 body의 raw string으로 반환 — **완료** (HttpOnly 쿠키 전환 + 메타 JSON)
+
+**위치**: `AuthController.java:31`
+
+```java
+return ResponseEntity.ok().body(newToken.getAccess_token());
+```
+
+- 응답 포맷 통일성, 메타데이터(만료시각 등) 확장 측면에서 모두 손해.
+- **수정**: `{ "accessToken": "...", "tokenType":"Bearer", "expiresIn": 600 }` JSON으로 응답.
+- 보수적 안: access token도 HttpOnly 쿠키로 내려 XSS 노출 표면 축소 검토.
+
+### ✅ S-5. JWT Secret 길이/시작시 검증 없음 — **완료** (32byte fail-fast)
+
+- HS256은 32바이트 이상 필요. 짧은 secret이면 첫 사용 시점에 런타임 예외.
+- `@PostConstruct`에서 길이 검증 + 시작 실패하는 게 안전.
+- **갱신(2026-05-22, Q-1)**: 초기 구현은 `JwtSecretValidator` `@PostConstruct`였으나, Q-1에서 `JwtProperties`(record) compact 생성자로 이전(바인딩 시점 fail-fast). `JwtSecretValidator` 삭제. 메시지 포맷(`"jwt.secret must be >= 32 bytes ..."`) 유지, `JwtPropertiesTest`로 회귀 가드.
+
+### ✅ S-6. Refresh token 쿠키가 세션 쿠키 — **완료**
+
+**위치**: `AuthController.java:30` → `CookieUtil.addCookie(name, value)` (maxAge 미지정 오버로드)
+
+- `refreshTokenExpiration = 14일`인데 쿠키는 브라우저 종료 시 사라짐 → 정책 불일치.
+- **수정**: `addCookie(name, value, (int)(refreshTokenExpiration / 1000))` 사용.
+
+### ✅ S-7. 쿠키 SameSite/도메인 정책 — **완료** (`CookieProperties`/`CookieFactory` 환경 분기)
+
+**위치**: `CookieUtil.java:13`
+
+- `SameSite=Lax` 고정. 프론트/백엔드 도메인이 다르면 cross-site POST에서 refresh 쿠키가 전송되지 않을 수 있음 → 분리 도메인이면 `SameSite=None; Secure` 필수.
+- `Secure=true` 고정 → 로컬 HTTP 개발 시 쿠키 미전송. 환경별 분기 권장.
+- 도메인 명시(`setDomain`) 없음.
+
+### ✅ S-8. `/api/v1/logout`이 GET — **완료** (`logout`·`reissuing-token` POST 전용화)
+
+- 상태 변경 액션인데 GET → prefetch/크롤러 우려, 시멘틱 불일치.
+- `POST /api/v1/logout`이 RESTful. B-3의 서버측 refresh 토큰 무효화와 함께 처리.
+
+---
+
+## 🟡 P2 — 코드 품질 / 유지보수성
+
+### ✅ Q-1. `JwtUtil`이 정적 메서드 모음 + `@Component` — **완료** (`260522_jwt-token-quality-plan.md`)
+
+- 빈으로 등록만 되고 정적 호출만 됨. 인스턴스 메서드로 전환하고 secret/SecretKey/expiration을 필드 캐싱 → 매 요청 `getBytes()`/`hmacShaKeyFor()` 재생성 제거.
+- 권장 구조: `JwtTokenProvider` 빈에서 `SecretKey` 1회 빌드, `createAccessToken/createRefreshToken/parse` 등 명시 메서드.
+
+**→ 완료**: `JwtTokenProvider` 빈 신설(생성자에서 `SecretKey`·issuer·audience·expiration 1회 캐싱, `createAccessToken`/`createRefreshToken`/`parse*`/`validate*` 명시 메서드). 흩어진 `@Value("${jwt.secret}")` 5개 지점을 `JwtProperties`(@ConfigurationProperties record) 한 곳으로 SSOT화. `JwtUtil`·`JwtSecretValidator` 삭제(32byte fail-fast는 `JwtProperties` compact 생성자가 흡수). 운영 코드 `@Value("${jwt.secret}")` 0건 확인.
+
+### ✅ Q-2. Token DTO 필드명 snake_case — **완료** (`260522_jwt-token-quality-plan.md`)
+
+**위치**: `Token.java`
+
+```java
+private String access_token;
+private String refresh_token;
+```
+
+- Java 컨벤션 위반. Lombok이 `getAccess_token()` 메서드 생성.
+- 외부 JSON 키만 snake로 유지하려면 필드는 camelCase + `@JsonProperty("access_token")`.
+
+**→ 완료**: S-4(쿠키 전환) 이후 `Token`은 외부 직렬화 경로가 없는 내부 운반체이고 `IssuedToken`(record)과 형태가 100% 중복이었음. rename 대신 **`Token` 삭제 후 `IssuedToken`으로 통합**(`AuthService.adminLogin` 반환 타입 `IssuedToken`, `AuthServiceImpl`이 `issueOnLogin` 결과를 재포장 없이 반환). snake_case 게터(`getAccess_token`/`getRefresh_token`) 잔존 0건.
+
+### ✅ Q-3. `LoginReqDto` 메시지가 실제 규칙과 불일치 — **완료** (`260524_auth-p2-remaining-plan.md`)
+
+**위치**: `LoginReqDto.java:13-16`
+
+- "공백/특수문자 입력 불가능", "`!@#$%` 외 특수문자 불가" 라고 안내하지만 `@Pattern`이 없어 **실제로는 모두 통과**.
+- **수정**: 로그인 DTO에는 포맷 게이트를 추가하지 않고, 실제 제약(`@NotBlank`, `@Size`)과 일치하도록 거짓 특수문자 안내를 제거. `GlobalExceptionHandler.handleValidation`에서 `password`/`token`/`secret` 계열 민감 필드의 `rejectedValue`를 `[PROTECTED]`로 마스킹.
+
+### ✅ Q-4. `/api/v1/token-validation` 엔드포인트 효용 — **완료** (`260524_auth-p2-remaining-plan.md`)
+
+- 보호 API 호출 시 401로 알 수 있고, 사전 검증해도 race condition 회피 안 됨 → 라운드트립 낭비.
+- 필요하면 access token 만료까지 남은 초(`expiresIn`) 반환이 더 유용.
+- **수정**: 현재 프론트 소비처가 없어 공개 계약을 제거. `AuthController.tokenValidate`, `AuthService.isTokenValid`, 관련 테스트와 RestDocs `auth.adoc`의 "토큰 인증" 섹션 삭제.
+
+### ✅ Q-5. JWT 표준 claim 미사용 — **완료** (`260522_jwt-token-quality-plan.md`)
+
+- `jti`, `iss`, `aud`, `nbf` 없음 → 향후 blacklist/다중 audience 운영 시 회수 어려움.
+- 최소 `jti`(UUID)는 부여해두면 future-proofing 효과 큼.
+
+**→ 완료**: access token에 `jti`(UUID)·`iss`·`aud`·`nbf` 부착, parser에 `requireIssuer`/`requireAudience` 강제검증 + `clockSkewSeconds(30)`. provider의 `parse*`/`validate*`가 jjwt 예외를 전부 도메인 예외로 매핑(`ExpiredJwtException`→`ExpiredTokenException`, 그 외 `JwtException`/`IllegalArgumentException`→`InvalidateTokenException`) → `require*` 강제로 새 발생하는 `MissingClaimException`/`IncorrectClaimException`이 `/reissuing-token` 500으로 누출되지 않음.
+- **이월**: access `jti` 소비(블랙리스트/강제 회수)는 미도입 — claim 심기까지만. `AccessTokenClaims` record에는 jti 미노출(소비 코드 부재). 블랙리스트 저장소 도입은 별도 작업.
+- **배포 주의**: `iss`/`aud` 강제검증으로 기존 발급 토큰 전량 무효화 → 어드민 재로그인 1회 필요. `application.yaml`/`application-test.yaml`에 non-blank `jwt.issuer`/`jwt.audience` 기본값 추가됨.
+
+### ✅ Q-6. role을 `"ROLE_ADMIN"` 단일 문자열로 박아둠 — **완료** (`260522_jwt-token-quality-plan.md`, `260524_auth-p2-remaining-plan.md`)
+
+- `/api/v1/token-role`이 `ROLE_` 접두사 그대로 프론트에 노출.
+- 응답 시 `"ADMIN"`으로 변환하거나 claim을 배열로 가져가는 게 확장에 유리.
+
+**→ 완료**: `Role` enum(`ADMIN("ROLE_ADMIN")`)으로 내부 authority를 SSOT화했고, 외부 `/token-role` 응답은 `Role.fromAuthority(authority).displayName()`으로 `"ADMIN"`을 반환한다. 프론트 `RoleGate.tsx`는 배포 순서 리스크를 줄이기 위해 `"ADMIN"`/`"ROLE_ADMIN"`을 모두 허용하는 전이 호환 상태로 변경.
+
+### ✅ Q-7. `AuthController.getToken()` 중복 — **완료 확인** (`260524_auth-p2-remaining-plan.md`)
+
+- `TokenResolver` 도입으로 컨트롤러와 `JwtFilter`가 쿠키 토큰 해석을 단일 경로로 사용한다. `AuthController.getToken()` 및 중복 `Bearer ` 파싱 코드는 남아 있지 않음. `authorizationHeaderOnlyCannotAccessProtectedApi` 테스트가 헤더 단독 인증 불가를 회귀 가드한다.
+
+### ✅ Q-8. 인증 시도 audit 로그 없음 — **완료** (`260524_auth-p2-remaining-plan.md`)
+
+- `AuthServiceImpl`에 로그인 성공/실패 로그 전무.
+- 어드민 인증 시도/성공/실패는 보안 감사상 최소 INFO 레벨로 남는 게 표준 (사용자명, IP, UA, 결과).
+- **수정**: 전용 `AUDIT` logger를 도입해 `LOGIN_SUCCESS`, `LOGIN_FAILURE`, `LOGIN_LOCKED`, `LOGOUT`, `TOKEN_REISSUE`, `TOKEN_REISSUE_REUSE_DETECTED`를 정형 `key=value` 한 줄로 기록. `UnauthorizedException`만 `LOGIN_FAILURE`로 기록해 잠금 이벤트와 중복되지 않게 했고, refresh reuse는 `InvalidateTokenException`의 `ErrorCode.REFRESH_TOKEN_REUSE_DETECTED`를 핸들러에서 판별해 기록한다.
+
+---
+
+## ✅ 잘 되어 있는 부분 (강점)
+
+- BCrypt(`PasswordEncoder.matches`) 사용 — 평문/단순 해시 아님.
+- HS256 + `Keys.hmacShaKeyFor` (jjwt 0.12.6 최신 API) — 약한 알고리즘 회피.
+- Stateless 세션 정책 (`SessionCreationPolicy.STATELESS`) 명시.
+- CORS allow-list가 환경변수 기반.
+- `ShouldNotFilterPath`의 GET/그 외 메서드 분리 매칭 — 의도 명확, prefix 충돌(`/api/v1/categories` ↔ `/api/v1/categories-management`)도 방지.
+
+---
+
+## 권장 작업 순서
+
+| 순서 | 작업 | 상태 | 비고 |
+|---|---|---|---|
+| 1 | **B-2 즉시 패치** | ✅ 완료 | `a2d6ae8` |
+| 2 | **B-1, B-4 동시 리팩토링** | ✅ 완료 | `a7c150f`, `26c3850` — `typ` claim + 시멘틱 정정 (단 `JwtTokenProvider` 신설은 Q-1로 미착수) |
+| 3 | **B-3 Refresh Token 회전 / Reuse Detection** | ✅ 완료 | `693af43` — Redis jti/family + Lua 원자 회전 |
+| 4 | S-1, S-2, S-3 묶음 보안 강화 PR | ✅ 완료 | S-1·S-3 `97844fc`, S-2 `6eaeb25` |
+| 5 | S-4 ~ S-7 쿠키·응답 정책 정비 | ✅ 완료 | S-4 HttpOnly 쿠키 전환·S-5 secret fail-fast·S-7 쿠키 정책 외부화·S-8 POST 전용화 (계획서 `260519_cookie-response-policy-plan.md`) |
+| 6 | P2 항목 점진 개선 | ✅ 완료 | Q-1·Q-2·Q-5 완료(`260522_jwt-token-quality-plan.md`), Q-3·Q-4·Q-6·Q-7·Q-8 완료(`260524_auth-p2-remaining-plan.md`) |
+
+---
+
+## 변경 영향 범위 메모
+
+- **B-1, B-4**: 토큰 형식 변경 → 운영중 발급된 모든 토큰은 무효화됨. 배포 시 사용자 재로그인 안내 필요.
+- **B-3**: Redis 의존성 추가 (이미 운영중인 Redis 재사용 가능). 기존 발급 refresh와의 호환을 위해 grace period 설계 필요.
+- **S-4**: 응답 포맷 변경 → 프론트엔드 `lib/apiClient.ts` / 로그인 처리 코드 동시 수정 필요.
+- **S-8**: HTTP 메서드 변경 → 프론트엔드 호출부 수정 필요.
+- **Q-5**: `iss`/`aud` 강제검증 도입 → 기존 발급 access/refresh 토큰 전량 무효화. 배포 시 어드민 재로그인 1회 필요(access 10분이라 영향 짧음). `jwt.issuer`/`jwt.audience`는 **non-blank** 값 필수(빈 값이면 부팅 실패).
+- **Q-6**: `/token-role` 응답이 `"ADMIN"`으로 변경됨. 프론트 `RoleGate.tsx`는 `"ADMIN"`/`"ROLE_ADMIN"` 전이 호환을 반영해 배포 순서 리스크를 완화.
+- **Q-4**: `/api/v1/token-validation` 공개 계약 제거. 외부 소비자가 있었다면 404가 발생하므로 배포 전 소비처 부재 재확인 필요.
+
+P0 항목(특히 B-2, B-3)은 운영에 실제 영향이 가므로 다음 작업 세션 1순위로 권장.

--- a/backend/docs/260524_auth-p2-remaining-plan.md
+++ b/backend/docs/260524_auth-p2-remaining-plan.md
@@ -1,0 +1,280 @@
+# 인증 도메인 잔여 P2 해결 계획서
+
+> 작성일: 2026-05-24
+> **구현 완료·검증: 2026-05-25** (실제 코드 검증 + `AuthControllerTest` 통과 — §7 참조)
+> 상위 문서: `260513_auth-controller-senior-review.md` (P2 항목 정의)
+> 선행 완료: `260522_jwt-token-quality-plan.md` (Q-1·Q-2·Q-5 완료, Q-6 부분)
+> 대상 잔여 항목: **Q-3, Q-4, Q-6(접두사 노출), Q-7(재확인), Q-8(audit 보강)**
+> 작업 범위: `-b` (단, Q-6은 프론트 동시 변경 필요 → `-b -f`)
+
+---
+
+## 0. 현재 상태 — 코드 기준 재검증 (커밋 메시지 아님)
+
+> 작업/리뷰 완료 여부는 실제 코드로 검증 후 반영한다는 원칙에 따라, 상위 리뷰 문서(2026-05-22 기준)와 **현재 코드의 차이**를 먼저 정정한다.
+
+| 항목 | 리뷰 문서 상태 | **실제 코드 상태 (2026-05-24 검증)** | 정정/비고 |
+|---|---|---|---|
+| Q-3 | ❌ 미착수 | ❌ 미착수 — `LoginReqDto`에 `@Pattern` 없음, 거짓 안내 메시지 유지 | 일치 |
+| Q-4 | ❌ 미착수 | ❌ 미착수 — `tokenValidate()`가 `ResponseEntity<Boolean>` 반환 | 일치. **추가 사실**: 프론트 `validateAccessToken()`는 정의만 있고 사용처 0건 (dead code) |
+| Q-6 | 🟡 부분 완료 | 🟡 — `/token-role`이 `"ROLE_ADMIN"` 원문 반환, 프론트 `RoleGate.tsx`가 `role !== "ROLE_ADMIN"` 결합 | 일치 |
+| Q-7 | ❌ 미착수 | ✅ **사실상 해소** — `TokenResolver`(쿠키 단일 해석)로 통합. `AuthController.getToken()`·중복 `Bearer ` 파싱 코드 부재 | **정정 필요**: 신규 작업 없음, "검증 후 종료" |
+| Q-8 | 🟡 부분 완료 (실패 warn만) | 🟡 — 실패 warn(`AuthCredentialVerifier`) + **성공 info도 존재**(`RefreshTokenServiceImpl:59`) | **정정**: 성공 로그는 이미 있음. 진짜 공백은 **IP·UA 미포함 + 분산된 비정형 포맷** |
+
+### 검증 근거 (파일·라인)
+
+- **Q-3**: `dto/auth/LoginReqDto.java:12-17` — `@NotBlank` + `@Size`만 존재. 메시지는 "공백 및 특수문자 입력 불가능", "`!@#$%`를 제외한 특수문자 불가"라고 안내하나 `@Pattern`이 없어 실제로는 전부 통과.
+- **Q-4**: `controller/AuthController.java:90-94` — `ResponseEntity<Boolean>`. 프론트 `lib/authApi.ts:22-23`에 `validateAccessToken` 정의는 있으나 grep 결과 호출처 0건.
+- **Q-6**: `AuthController.java:60-71`(`getRoleFromToken` → `getTokenInfo(token).getRole()` → `"ROLE_ADMIN"`), `frontend/components/management/RoleGate.tsx:43`(`role !== "ROLE_ADMIN"`).
+- **Q-7**: `utils/TokenResolver.java`(쿠키 단일 해석), `JwtFilter.java:43`·`AuthController.java:62,92`가 모두 `tokenResolver.resolve(request)` 사용. 코드 전역 `Bearer`/`getToken`/`substring(7)` grep → 컨트롤러 라벨(`TokenMetaResponse("Bearer", ...)`)과 CORS `setExposedHeaders` 외 토큰 파싱 중복 없음.
+- **Q-8**: `AuthCredentialVerifier.java:26,30`(실패 warn, username/IP/UA 없음), `RefreshTokenServiceImpl.java:59`(로그인 성공 info, id/family만)·`:95`(로그아웃 info, family만)·`:126`(reuse 탐지 warn, family만), `GlobalExceptionHandler.java:43`(잠금 429 warn, retryAfter만)로 **여러 클래스에 분산·비정형**. `ClientIpResolver`가 `adminLogin(dto, clientIp)`로 IP를 넘기지만 **로깅되지 않음**, UA는 어디서도 수집 안 함. (참고: `GlobalExceptionHandler.handleValidation:85-99`은 어떤 로그도 남기지 않음 → Q-3 비번 누출은 *응답 본문* 한정)
+
+### 범위 외 — 조사 중 발견한 별도 이슈 (이번 계획에 미포함, 별도 처리 권장)
+
+1. **프론트 인증 호출 메서드 불일치 (실동작 버그, `-f`)**: `lib/authApi.ts`의 `logout`(14-15행, `axios.get` 15행)·`reissuingAccessToken`(17-20행, `axios.get` 19행)이 `axios.get`인데, 백엔드는 S-8로 `@PostMapping` 전용화됨 → 현재 **405 Method Not Allowed**. 백엔드 테스트 `getLogoutAndGetReissuingTokenAreMethodNotAllowed`가 405를 보장하고 있으므로 프론트가 깨진 상태. → 별도 `-f` 핫픽스 필요.
+2. **Q-4 dead code**: 위 1과 함께 프론트 정리 시 `validateAccessToken` export 제거 검토.
+
+> #2(dead export)는 Q-6 프론트 세션에서 함께 처리하면 효율적이다. **단 #1(GET→POST)은 단순 정리가 아니라 로그아웃·재발급이 현재 405로 깨진 실동작 인증 버그이므로, Q-6보다 먼저 처리하는 선행 핫픽스(`-f`)로 격상한다.**
+
+---
+
+## 1. Problem (문제 정의)
+
+잔여 P2는 "버그"보다는 **품질/유지보수성/감사성**의 결함이다. 방치 시:
+
+- **Q-3** (`dto/auth/LoginReqDto.java:13,16`): 검증 메시지가 거짓("공백 및 특수문자 입력 불가능" 등을 안내하나 `@Pattern`이 없어 전부 통과) → 사용자/리뷰어가 실제 규칙을 오해. 또한 `MethodArgumentNotValidException` 핸들러가 `rejectedValue`를 응답 본문에 그대로 echo(`exception/GlobalExceptionHandler.java:91-92`)하므로, **비밀번호 `@Size` 위반 시 입력 비밀번호가 400 응답 본문에 노출**되는 잠재 누출이 이미 존재. (※ 해당 핸들러는 로깅을 하지 않으므로 *로그* 노출은 아님 — "응답 본문" 한정)
+- **Q-4** (`controller/AuthController.java:90-94`, `frontend/lib/authApi.ts:22`): 효용 낮은 엔드포인트(`Boolean`)가 공개 표면으로 남아 유지보수 비용·오해 유발. 프론트 소비처도 없음(dead export).
+- **Q-6** (`controller/AuthController.java:60-71`, `domain/token/Role.java:4`, `frontend/components/management/RoleGate.tsx:43`): Spring 내부 권한 접두사(`ROLE_`)가 외부 계약으로 굳어짐 → 권한 확장/표현 변경 시 프론트와 강결합.
+- **Q-7** (`utils/TokenResolver.java`, `configuration/JwtFilter.java:43`): (이미 해소) 미해소로 문서에 남아 있어 작업 추적이 부정확.
+- **Q-8** (`service/implementation/AuthCredentialVerifier.java:26,30`, `RefreshTokenServiceImpl.java:59,95,126`, `exception/GlobalExceptionHandler.java:43`): 어드민 단일 계정 시스템에서 **누가·어디서(IP)·무엇으로(UA)·언제·결과** 형태의 감사 추적이 비정형·부분적(여러 클래스에 분산) → 침해 사고 분석/이상 탐지 곤란.
+
+---
+
+## 2. 항목별 분석 및 결정 (Analyze + Decision)
+
+### Q-3. `LoginReqDto` 메시지 ↔ 실제 검증 불일치
+
+**선택지**
+
+| 안 | 내용 | 장점 | 단점/리스크 |
+|---|---|---|---|
+| A. `@Pattern`으로 규칙 강제 | `username`/`password`에 정규식 부착 | 메시지와 동작 일치 | **로그인 DTO에 포맷 강제는 안티패턴**. 기존 어드민 비밀번호가 패턴 외 문자를 포함하면 BCrypt 비교 전에 400 → **영구 락아웃**. 회원가입/비번변경 엔드포인트가 없어(단일 어드민) 보안 이득 0 (BCrypt가 이미 임의 입력 처리) |
+| B. 거짓 안내 제거 + 최소 제약 유지 | 메시지에서 "특수문자 불가" 등 허위 문구 삭제, `@NotBlank`+`@Size`만 유지 | 락아웃 위험 0, 정직한 계약 | "강한 검증"이라는 외형은 사라짐(실익 없음) |
+| C. 메시지대로 느슨한 패턴 | `!@#$%` 허용 패턴으로 맞춤 | 메시지·동작 일치 | 여전히 기존 비번이 패턴 밖이면 락아웃 위험 |
+
+**결정: B (거짓 안내 제거 + 최소 제약)** + **비밀번호 `rejectedValue` 마스킹**.
+
+- 근거: 로그인 검증은 "포맷 게이트"가 아니라 "빈 값/극단 길이 방어"가 목적이다. 포맷 강제는 등록 시점에 두는 것이 표준이며, 본 시스템엔 등록 경로가 없다. A/C는 운영 어드민 락아웃이라는 비가역 리스크 대비 이득이 없다.
+- 부수 보안 개선: `GlobalExceptionHandler.handleValidation`이 **민감 필드의 `rejectedValue`를 응답 본문에 넣지 않도록 마스킹**. `password` 단일 비교가 아니라 민감 필드명 집합(`password`, `oldPassword`, `newPassword`, `confirmPassword`, `token`, `secret`)을 판별하는 helper(`isSensitiveField(fieldName)`)로 `value`를 `"[PROTECTED]"`로 치환한다. `handleValidation`은 **전 검증 응답에 공통 적용**되는 로직이므로(현재는 `LoginReqDto.password`만 해당하나) 방어적으로 일반화해 향후 DTO 추가 시 누출을 사전 차단. 이는 Q-3 메시지 정정과 동일 맥락의 정보 누출 차단.
+
+### Q-4. `/api/v1/token-validation` 효용
+
+**선택지**
+
+| 안 | 내용 | 장점 | 단점 |
+|---|---|---|---|
+| A. 엔드포인트 제거 | `tokenValidate()` + `AuthService.isTokenValid` 삭제 | 공개 표면·dead code 최소화. 보호 API는 어차피 401로 신호 | 향후 "사전 갱신" 용도 재구현 비용 |
+| B. `expiresIn`으로 용도 변경 | `{ valid, expiresIn }` 반환 → 만료 임박 시 선제 reissue | 능동적 silent-refresh 가능 | 현재 소비처 없음 → 투기적 구현(YAGNI) |
+| C. 유지(Boolean) | 변경 없음 | - | 효용 낮음·오해 지속 |
+
+**결정: A (계약 제거)** — 단, "선제 갱신 UX를 곧 도입"할 계획이면 B, **외부 소비자 부재를 100% 확신할 수 없으면 D(`@Deprecated` 후 단계 제거)**.
+
+- 근거: 프론트 소비처가 0건이고, 보호 API 호출 시 401 + reissue 플로우가 이미 동일 정보를 더 정확히(race-free) 제공한다. 미사용 공개 엔드포인트는 공격 표면이자 인지 부채다.
+- **이것은 "제품 기능"이 아니라 "공개 API 계약"의 제거다.** 따라서 제거 범위는 코드뿐 아니라 **문서 표면 전체**를 포함한다:
+  - 코드: 엔드포인트 + `isTokenValid`(인터페이스 `AuthService:20` / 구현) + 테스트(`tokenValidate`, `tokenValidateWithoutValidCookie`)
+  - **Asciidoc: `src/docs/asciidoc/auth.adoc:14-15`의 "토큰 인증" 섹션**(`operation::auth-controller-test/token-validate[...]`) — 미삭제 시 스니펫 누락으로 `asciidoctor` 태스크가 **실패**한다
+  - 정적 산출물(`src/main/resources/static/docs`)은 `createDocument` 태스크가 재생성하므로 별도 수정 불필요
+  - 프론트 dead export `validateAccessToken` 제거는 위 "범위 외 #2"와 함께
+- **D(Deprecated) 옵션**: 외부 소비자 존재가 불확실하면 즉시 제거 대신 `@Deprecated` + 문서 폐기예정 표기 → 한 사이클 관찰 후 제거.
+- **이 항목은 공개 계약 변경 포인트** → 구현 착수 전 사용자 확인 권장(아래 §5 참고). 기본 권고는 A.
+
+### Q-6. `ROLE_` 접두사 외부 노출 정리 (`-b -f`)
+
+**선택지**
+
+| 안 | 내용 | 장점 | 단점 |
+|---|---|---|---|
+| A. `/token-role`이 `"ADMIN"` 반환 | 접두사 제거(`Role.ADMIN.name()` 또는 매핑) + 프론트 `"ADMIN"` 비교 | 내부 권한 모델과 외부 계약 분리 | 백엔드·프론트 동시 배포 필요 |
+| B. 구조화 응답 `{ "roles": ["ADMIN"] }` | 다중 권한 확장 대비 | 미래 확장성 | 계약 변경 폭 큼, 현재 단일 권한이라 과설계 |
+
+**결정: A** — 단일 권한 시스템에 배열은 과설계. 응답을 `"ADMIN"`(접두사 제거 문자열)로 단순화.
+
+- **배포 순서 리스크(핵심)**: 백엔드만 먼저 배포되면 구버전 프론트(`role !== "ROLE_ADMIN"`)가 `"ADMIN"`을 비-어드민으로 판정 → **어드민이 `/management`에서 홈으로 튕김**.
+- **완화책**: 프론트 `RoleGate`를 **전이 호환**으로 먼저 배포 — `role === "ADMIN" || role === "ROLE_ADMIN"`. 이후 백엔드 배포. 안정화 후 `"ROLE_ADMIN"` 분기 제거(정리 커밋). 이렇게 하면 배포 순서 무관.
+- 변환 위치·방식: `domain/token/Role.java`에 **명시 매핑**을 둔다 — `displayName()`(`ADMIN` 반환)과 역매핑 `fromAuthority(String authority)`(**정의되지 않은 authority는 예외 처리**). 컨트롤러는 `Role.fromAuthority(authority).displayName()`로 변환. **문자열 치환(`replaceFirst("ROLE_", "")`)은 금지** — 잘못된/미정의 권한 값도 그럴듯한 외부 값으로 흘려보내 계약을 오염시킬 수 있다. 내부 SecurityContext 권한(`ROLE_ADMIN`)은 절대 변경하지 않는다(Spring `hasRole` 계약 보존).
+
+### Q-7. Bearer 파싱 중복 — **신규 작업 없음, 검증 후 종료**
+
+- `TokenResolver` 도입으로 토큰 해석이 단일화되었고(쿠키 기반), 컨트롤러/필터의 중복 `Bearer ` 파싱과 `AuthController.getToken()`이 모두 사라졌다.
+- 기존 테스트 `authorizationHeaderOnlyCannotAccessProtectedApi`가 "헤더만으로는 401"을 이미 보장.
+- **조치**: 상위 리뷰 문서 표를 ✅로 갱신. 추가로, 회귀 방지를 위해 "토큰 해석은 `TokenResolver` 단일 경로" 주석/테스트가 충분한지 확인만 한다. 코드 변경 불필요.
+
+### Q-8. 인증 audit 로그 정형화 (IP·UA·결과)
+
+**선택지**
+
+| 안 | 내용 | 장점 | 단점 |
+|---|---|---|---|
+| A. 기존 로그에 IP/UA 인자 추가 | 분산 로그에 필드만 보강 | 최소 변경 | UA는 웹 계층 관심사 → 서비스/도메인 계층까지 `HttpServletRequest` 누수. 포맷 비일관 유지 |
+| B. 전용 `AuthAuditLogger` (권장) | 컨트롤러 경계(요청 객체 보유)에서 정형 이벤트 기록. 전용 logger 네임(`AUDIT`)으로 별도 appender 라우팅 가능 | 정형·단일 책임·웹 관심사 격리·운영 분리 용이 | 신규 컴포넌트 1개 추가 |
+| C. MDC + 필터 | requestId/IP/UA를 MDC로 전 로그에 주입 | 전역 상관관계 | 인증 감사 목적엔 과함, 패턴 정착 비용 |
+
+**결정: B (`AuthAuditLogger`)**.
+
+- **이벤트 taxonomy**: `LOGIN_SUCCESS`, `LOGIN_FAILURE`, `LOGOUT`, `TOKEN_REISSUE`, `TOKEN_REISSUE_REUSE_DETECTED`, `LOGIN_LOCKED`(429).
+- **공통 필드(정형, key=value 한 줄)**: `event`, `result`(SUCCESS/FAILURE), `username`(실패 포함 — 감사 목적이라 기록. **단 S-1과 무관**: S-1은 HTTP *응답* 차별 금지일 뿐 서버 로그 기록은 표준), `ip`, `ua`, `reason`(실패 사유 코드), `ts`(자동). **`password`는 절대 기록 금지**.
+- **호출 위치 (이벤트별 정확한 기록 지점 — 이중 기록·오분류 방지)**:
+  - `LOGIN_SUCCESS`: `AuthController.login`에서 `adminLogin` 정상 반환 후. IP·UA(`request.getHeader("User-Agent")`)는 컨트롤러에서 확보.
+  - `LOGIN_FAILURE`: `AuthController.login`에서 **`catch (UnauthorizedException)`로만 한정**해 audit + rethrow. `TooManyLoginAttemptsException`도 `BusinessException` 하위이므로(`AuthServiceImpl.adminLogin:35,42`에서 발생) 넓은 `catch`로 잡으면 LOGIN_FAILURE와 LOGIN_LOCKED가 **이중 기록**된다 → 반드시 예외 타입을 좁혀 잡는다. (5회째 실패는 서비스가 `UnauthorizedException` 대신 `TooManyLoginAttemptsException`을 던지므로 LOCKED 한 건만 남음)
+  - `LOGIN_LOCKED`: `GlobalExceptionHandler.handleTooManyLoginAttempts`(`:40-48`)에서만 기록. IP·UA가 필요하면 핸들러에 `HttpServletRequest` 파라미터 추가.
+  - `LOGOUT`/`TOKEN_REISSUE`(정상): 해당 컨트롤러 메서드(`logout`/`reissuingAccessToken`)에서 정상 처리 후 기록.
+  - `TOKEN_REISSUE_REUSE_DETECTED`: **reuse는 `RefreshTokenServiceImpl.rotate:125-127` 내부에서만 정확히 판별**되고(`InvalidateTokenException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED)`), 컨트롤러의 일반 catch(`InvalidateTokenException | ExpiredRefreshTokenException`)는 reuse·만료·위조·누락을 **구분하지 못한다**. 따라서 컨트롤러에서 추측하지 말고, **`GlobalExceptionHandler.handleInvalidateTokenException`이 `e.getErrorCode() == REFRESH_TOKEN_REUSE_DETECTED`일 때** 기록(여기서 IP·UA 확보 가능).
+- **계층 책임 분리(핵심)**: 웹 계층 `AuthAuditLogger`는 요청 객체(IP·UA)를 가진 **컨트롤러/핸들러 경계**에서만 호출한다. 서비스/도메인 계층은 `HttpServletRequest`를 받지 않으며(도메인 청결 유지), 서비스 내부에서만 알 수 있는 보안 신호(reuse)는 **ErrorCode로 표현**해 핸들러가 audit하도록 위임한다. 서비스의 기존 `warn`(`:126`)은 detection-layer 보안 신호로 유지(승격이 아니라 병행).
+- **중복 정리**: `AuthCredentialVerifier`의 ad-hoc `warn`(`:26,30`)과 `RefreshTokenServiceImpl`의 `info("Admin login...")`(`:59`)·`info("Admin logout...")`(`:95`)는 audit 로거로 일원화 후 `debug`로 강등하거나 제거(중복 로그 방지). 단, reuse 탐지 `warn`(`RefreshTokenServiceImpl:126`)과 잠금 `warn`(`GlobalExceptionHandler:43`)은 보안 신호라 유지하고, 웹 계층(핸들러)에서 각각 `TOKEN_REISSUE_REUSE_DETECTED`·`LOGIN_LOCKED` audit 이벤트를 **병행 기록**한다(승격이 아니라 detection-layer warn 유지 + 웹 계층 audit 추가 — 위 "호출 위치" 참조).
+- **운영**: logger 네임을 `AUDIT`로 분리해 `logback`에서 별도 파일/레벨로 라우팅 가능하도록 설계(설정 추가는 선택). 최소 INFO 레벨.
+
+---
+
+## 3. Action (구현 계획)
+
+### 작업 범위·순서
+
+> 작은 것부터, 프론트 결합 항목은 뒤로.
+
+0. **선행 핫픽스** — `frontend/lib/authApi.ts`의 `logout`/`reissuingAccessToken` GET→POST 수정(현재 405 인증 버그). [`-f`, **Q-6 이전 필수**]
+1. **Q-7** — 문서만 ✅ 갱신 (코드 무변경). [백엔드 PR과 무관, 즉시]
+2. **Q-3** — `LoginReqDto` 메시지 정정 + 민감 필드 `rejectedValue` 마스킹. [백엔드 단독]
+3. **Q-8** — `AuthAuditLogger` 도입 + 호출부 배선(컨트롤러/핸들러 경계) + 기존 로그 정리. [백엔드 단독]
+4. **Q-4** — (사용자 결정 후) 엔드포인트/`isTokenValid`/`auth.adoc` 섹션 제거 **또는** `expiresIn` 전환 **또는** `@Deprecated`. [백엔드 단독, 프론트 dead export 정리 동반]
+5. **Q-6** — `/token-role` 응답 `"ADMIN"` 전환. [`-b -f`, 배포 순서 주의 — 프론트 전이 호환 먼저]
+
+### 변경 대상 파일 목록
+
+**백엔드**
+
+| 파일 | 변경 | 항목 |
+|---|---|---|
+| `dto/auth/LoginReqDto.java` | 거짓 안내 메시지 제거, 메시지를 실제 제약(`@NotBlank`/`@Size`)과 일치 | Q-3 |
+| `exception/GlobalExceptionHandler.java` | (Q-3) `handleValidation`에 민감 필드명 집합 마스킹 helper(`isSensitiveField` → `[PROTECTED]`); (Q-8) `handleInvalidateTokenException`에서 `REFRESH_TOKEN_REUSE_DETECTED` 시 `TOKEN_REISSUE_REUSE_DETECTED` audit, `handleTooManyLoginAttempts`에서 `LOGIN_LOCKED` audit | Q-3·Q-8 |
+| `utils/AuthAuditLogger.java` (신규) | 정형 감사 이벤트 기록 컴포넌트 | Q-8 |
+| `controller/AuthController.java` | login/logout/reissue에 audit 호출 + UA 수집, (Q-4) `tokenValidate` 제거 or 변경, (Q-6) role 표현 변환 | Q-4·Q-6·Q-8 |
+| `service/AuthService.java` + `…/AuthServiceImpl.java` | (Q-4 A안) `isTokenValid` 제거 | Q-4 |
+| `service/implementation/AuthCredentialVerifier.java` | ad-hoc warn → debug 강등/제거(audit로 일원화) | Q-8 |
+| `service/implementation/RefreshTokenServiceImpl.java` | `info("Admin login...")` 중복 정리, reuse 탐지를 audit 이벤트로 승격 | Q-8 |
+| `domain/token/Role.java` | (Q-6) 명시 매핑 헬퍼 `displayName()` + `fromAuthority(String)`(미정의 authority는 예외) 추가 — 문자열 치환 금지 | Q-6 |
+| `docs/asciidoc/auth.adoc` | (Q-4 A안) `:14-15` "토큰 인증" 섹션 제거(스니펫 참조 삭제) | Q-4 |
+
+**프론트 (`-f` 세션)**
+
+| 파일 | 변경 | 항목 |
+|---|---|---|
+| `components/management/RoleGate.tsx` | 전이 호환(`=== "ADMIN" \|\| === "ROLE_ADMIN"`) → 안정화 후 `"ADMIN"`만 | Q-6 |
+| `lib/authApi.ts` | (범위 외 동반) `logout`/`reissuingAccessToken` GET→POST 수정, dead `validateAccessToken` 제거 | 부수·Q-4 |
+
+### 주요 트레이드오프
+
+- **Q-3**: 검증 강화 외형 포기 ↔ 어드민 락아웃 비가역 리스크 회피 + 비번 누출 차단. (정직성·안전성 우선)
+- **Q-4**: 확장 옵션(`expiresIn`) 보류 ↔ 표면/부채 축소. (YAGNI)
+- **Q-6**: 동시 배포 제약 ↔ 내부/외부 모델 분리. (전이 호환으로 제약 완화)
+- **Q-8**: 컴포넌트 1개 추가 ↔ 감사성·관심사 격리. (운영 가치 큼)
+
+### 예상 이슈 & 대응
+
+- **Q-6 배포 순서** → 프론트 전이 호환 먼저 배포(필수).
+- **Q-8 username 로깅 vs S-1** → 응답이 아닌 *서버 로그*이므로 충돌 없음. 비번은 절대 미기록.
+- **Q-8 LOGIN_FAILURE/LOGIN_LOCKED 이중 기록** → `login`의 audit catch를 `UnauthorizedException`으로만 한정(`TooManyLoginAttemptsException`은 `BusinessException` 하위라 넓은 catch에 걸림). 잠금은 핸들러에서만 `LOGIN_LOCKED` 기록.
+- **Q-8 reuse 오분류** → 컨트롤러 일반 catch는 reuse를 구분 못 함. `handleInvalidateTokenException`에서 `ErrorCode == REFRESH_TOKEN_REUSE_DETECTED`로 판별해 기록(§2 호출 위치 참조).
+- **Q-4 제거 시 문서 파이프라인** → 테스트(`tokenValidate`/`tokenValidateWithoutValidCookie`)와 `auth.adoc:14-15` 섹션을 **함께** 제거해야 `asciidoctor`(`dependsOn test`) → `createDocument` → `bootJar` 체인이 깨지지 않음(스니펫 누락 시 asciidoctor 실패).
+- **Q-8 테스트 안정성** → 로그 어서션은 `OutputCaptureExtension`(Spring Boot) 또는 Logback `ListAppender`로 검증.
+
+---
+
+## 4. Result (검증 계획)
+
+> CLAUDE.md 규칙 4: 변경과 **직접 관련된 테스트만** 선택 실행.
+
+### 테스트
+
+- **Q-3**: `LoginController/AuthControllerTest`에 (a) 빈 값 400, (b) 길이 위반 400, (c) **400 응답 본문에 입력 비밀번호 문자열이 포함되지 않음**(마스킹) 검증 추가.
+- **Q-4 (A안)**: `tokenValidate`·`tokenValidateWithoutValidCookie` 테스트 제거 + `auth.adoc:14-15` "토큰 인증" 섹션 제거 후 **`./gradlew asciidoctor`(→ `createDocument` → `bootJar`) 문서 생성 성공까지 확인**(스니펫 누락 시 asciidoctor 실패로 회귀 감지). (B안 채택 시: `expiresIn` 필드 검증으로 교체)
+- **Q-6**: `getTokenFromRole` 회귀 가드를 `content().string("ROLE_ADMIN")` → `"ADMIN"`으로 변경. 프론트는 어드민 진입 시 게이트 통과를 수동/E2E 확인(전이 호환 단계 포함).
+- **Q-7**: 신규 테스트 불필요 — `authorizationHeaderOnlyCannotAccessProtectedApi`가 이미 커버. 문서 갱신만.
+- **Q-8**: `OutputCaptureExtension`으로 (a) 로그인 성공/실패 시 `event=LOGIN_SUCCESS/LOGIN_FAILURE`, `ip=`, `ua=` 포함 및 `password` 미포함, (b) **잠금(5회째) 발생 시 `LOGIN_LOCKED`만 기록되고 `LOGIN_FAILURE`는 중복 기록되지 않음**, (c) reuse 탐지 시 `TOKEN_REISSUE_REUSE_DETECTED` 기록을 어서션.
+
+```bash
+# 관련 테스트만 (전체 ./gradlew test 금지)
+./gradlew test --tests "com.moya.myblogboot.controller.AuthControllerTest"
+# (Q-8 audit 테스트 클래스 추가 시 함께)
+./gradlew test --tests "com.moya.myblogboot.*Auth*"
+```
+
+### 성공 기준
+
+- [x] Q-3: 검증 메시지가 실제 동작과 일치(거짓 특수문자 안내 제거), 400 응답 본문에 비밀번호 미노출(`rejectedValue` 마스킹). — `loginValidationMasksSensitiveRejectedValue` 통과
+- [x] Q-4: 미사용 엔드포인트·`isTokenValid`·`auth.adoc` "토큰 인증" 섹션 제거, 코드/테스트/문서에 dangling 참조 0건(`token-validate` grep 0). (A안 채택)
+- [x] Q-6: 백엔드 `"ADMIN"` 반환(`Role.fromAuthority().displayName()`), 프론트 전이 호환(`"ADMIN" \|\| "ROLE_ADMIN"`). — `getTokenFromRole` → `content().string("ADMIN")` 통과
+- [x] Q-7: 코드 무변경 확인, 상위 문서 표 ✅ 갱신 완료.
+- [x] Q-8: 6개 이벤트(`LOGIN_SUCCESS/FAILURE/LOCKED`, `LOGOUT`, `TOKEN_REISSUE`, `TOKEN_REISSUE_REUSE_DETECTED`)를 `AUDIT` 로거로 정형 한 줄 기록, **잠금 시 FAILURE 미중복**(테스트 가드), reuse는 핸들러에서 기록, 비번 미기록. — `loginWithWrongPassword`/`loginBruteForceProtection` 통과
+- [x] 변경 영향 테스트(`AuthControllerTest`) 전부 통과, 디버그 로그는 `debug` 강등 처리, 사이드 이펙트 점검 완료.
+
+---
+
+## 5. 구현 결정
+
+이번 구현은 기본 권고안으로 진행한다.
+
+1. **Q-4**: 엔드포인트 **계약 제거**.
+2. **Q-6 배포**: 프론트 **전이 호환 선반영** 후 백엔드 `/token-role`을 `"ADMIN"`으로 전환.
+
+---
+
+## 6. 상위 리뷰 문서 갱신 사항 (구현 완료 후 반영)
+
+- Q-7: ❌ → ✅ ("TokenResolver 단일화로 해소, 코드 무변경 확인").
+- Q-8: 🟡 사유를 "성공/실패 로그는 존재했으나 IP·UA·정형성 부재" → 보강 완료로 정정.
+- Q-3/Q-4/Q-6: 완료 시 상태·근거 갱신.
+
+> ✅ 위 갱신은 `260513_auth-controller-senior-review.md`에 2026-05-25 자로 반영 완료(전 항목 ✅, 진행 상황 표/변경 영향 메모 포함).
+
+---
+
+## 7. 구현 결과 — 코드 검증 (2026-05-25)
+
+> 원칙: 완료 여부는 커밋 메시지가 아니라 **실제 코드 + 테스트**로 검증한다. 아래는 본 계획서와 실제 구현의 대조 결과다.
+
+### 항목별 구현 확인 (파일·라인)
+
+| 항목 | 계획 | 실제 구현 (검증 위치) | 상태 |
+|---|---|---|---|
+| Q-3 메시지 | 거짓 안내 제거 | `LoginReqDto.java:13,16` — 특수문자 안내 삭제, `@NotBlank`/`@Size`만 | ✅ |
+| Q-3 마스킹 | 민감 필드 helper | `GlobalExceptionHandler.java:34-41,158-175` — `SENSITIVE_FIELDS`(`password`/`token`/`secret` 계열) + `maskRejectedValue`/`isSensitiveField` | ✅ 계획+α |
+| Q-4 엔드포인트 | 제거 | `AuthController`의 `tokenValidate` 삭제, `AuthService.java`에서 `isTokenValid` 삭제 | ✅ |
+| Q-4 문서 | `auth.adoc` 섹션 삭제 | `auth.adoc`에서 "토큰 인증"(`token-validate`) 제거, dangling 참조 0건 | ✅ |
+| Q-4 프론트 | dead export 제거 | `frontend/lib/authApi.ts` — `validateAccessToken` export 삭제 | ✅ |
+| Q-6 변환 | `displayName`/`fromAuthority` | `Role.java:18-27`(미정의 authority → `IllegalArgumentException`), `AuthController.java:81` 변환 | ✅ |
+| Q-6 프론트 | 전이 호환 | `RoleGate.tsx:43` — `role !== "ADMIN" && role !== "ROLE_ADMIN"` | ✅ |
+| Q-7 | 코드 무변경 | `TokenResolver` 단일 경로 유지 | ✅ |
+| Q-8 로거 | `AuthAuditLogger` 신설 | `utils/AuthAuditLogger.java` — `AUDIT` 로거, 6개 이벤트 enum, `event=...` 정형 한 줄 | ✅ |
+| Q-8 호출부 | 컨트롤러/핸들러 경계 | `AuthController.java:49-56`(login, `catch (UnauthorizedException)` 한정)·`69`(LOGOUT)·`97`(TOKEN_REISSUE), `GlobalExceptionHandler.java:61`(LOGIN_LOCKED)·`89-91`(REUSE) | ✅ |
+| Q-8 로그 정리 | warn→debug, info 제거 | `AuthCredentialVerifier.java:26,30`(`warn`→`debug`), `RefreshTokenServiceImpl`의 로그인/로그아웃 `info` 제거, reuse `warn`(`:124`)은 detection 신호로 유지 | ✅ |
+| 선행 핫픽스 | GET→POST | `authApi.ts` — `logout`/`reissuingAccessToken` `axios.post`로 수정 | ✅ |
+
+### 계획 대비 개선점 (구현 중 보강)
+
+- **로그 인젝션 방어**: `AuthAuditLogger.safe()`가 공백을 `_`로 치환해 `key=value` 한 줄 포맷 붕괴·로그 위조를 차단.
+- **마스킹 견고화**: `isSensitiveField`가 대소문자 무시 + 중첩 필드(`obj.password`)의 마지막 세그먼트까지 판별.
+- **이중 기록 회귀 가드**: `loginBruteForceProtection` 테스트가 잠금 발생 시 `LOGIN_LOCKED` 이후 `LOGIN_FAILURE`가 추가 기록되지 않음을 단언.
+
+### 테스트 결과
+
+- `./gradlew test --tests "com.moya.myblogboot.controller.AuthControllerTest"` → **BUILD SUCCESSFUL**. 변경된 인증 테스트(`AuthControllerTest`·`GlobalExceptionHandlerTest`·`AuthServiceImplTest`) 전부 통과.
+- 핵심 가드: `loginValidationMasksSensitiveRejectedValue`(Q-3), `getTokenFromRole`→`"ADMIN"`(Q-6), `loginWithWrongPassword`/`loginBruteForceProtection`(Q-8, `event=LOGIN_FAILURE`/`LOGIN_LOCKED` + 이중기록 가드).
+- Q-4 문서 파이프라인: `src/docs/asciidoc`에 `token-validate` 참조 0건 → `asciidoctor` 스니펫 누락 위험 없음.
+- **`./gradlew bootJar`(전체 테스트 동반)는 현재 BUILD FAILED** — `PostControllerTest`/`CategoryControllerTest`/`FileUploadControllerTest`에서 19건 실패(대부분 401·S3). **단, 본 작업과 무관한 기존(pre-existing) 결함**으로 확인: 변경분을 `git stash`로 제거한 HEAD 상태에서도 33건 중 19건 동일 실패 재현 → 인증 P2 변경의 회귀 아님. (정적 docs 재생성용 `bootJar` 성공은 위 비인증 테스트 선결 필요)
+
+### 잔여 / 후속
+
+- **배포 순서(Q-6)**: 프론트 전이 호환은 이미 반영됨 → 백엔드 `/token-role`=`"ADMIN"` 배포 후, 안정화되면 프론트에서 `"ROLE_ADMIN"` 분기 제거(정리 커밋).
+- **선택 운영**: `logback`에서 `AUDIT` 로거를 별도 appender/파일로 분리(현재는 logger 네임만 분리, 설정은 미적용).
+
+---

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -11,11 +11,8 @@ operation::auth-controller-test/login[snippets='request-fields,request-body,http
 operation::auth-controller-test/logout[snippets='http-request,http-response']
 
 == 토큰 관리
-=== 토큰 인증
-operation::auth-controller-test/token-validate[snippets='request-headers,http-request,http-response']
-
 === 토큰 권한 정보
-operation::auth-controller-test/get-token-from-role[snippets='request-headers,http-request,http-response']
+operation::auth-controller-test/get-token-from-role[snippets='http-request,http-response']
 
 === 토큰 재발급
 operation::auth-controller-test/reissuing-access-token[snippets='http-request,http-response']

--- a/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.moya.myblogboot.controller;
 
 import com.moya.myblogboot.configuration.JwtProperties;
+import com.moya.myblogboot.domain.token.Role;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.token.TokenMetaResponse;
 import com.moya.myblogboot.domain.token.IssuedToken;
@@ -8,8 +9,10 @@ import com.moya.myblogboot.domain.token.ReissuedToken;
 import com.moya.myblogboot.exception.custom.ExpiredTokenException;
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.service.AuthService;
 import com.moya.myblogboot.service.RefreshTokenService;
+import com.moya.myblogboot.utils.AuthAuditLogger;
 import com.moya.myblogboot.utils.ClientIpResolver;
 import com.moya.myblogboot.utils.CookieFactory;
 import com.moya.myblogboot.utils.CookieUtil;
@@ -23,6 +26,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moya.myblogboot.utils.AuthAuditLogger.AuthAuditEvent.*;
 import static com.moya.myblogboot.constants.CookieName.*;
 
 @RestController
@@ -35,13 +39,21 @@ public class AuthController {
     private final CookieFactory cookieFactory;
     private final TokenResolver tokenResolver;
     private final JwtProperties jwtProperties;
+    private final AuthAuditLogger authAuditLogger;
 
     @PostMapping("/api/v1/login")
     public ResponseEntity<TokenMetaResponse> login(@RequestBody @Valid LoginReqDto loginReqDto,
                                                    HttpServletRequest request,
                                                    HttpServletResponse response) {
-        IssuedToken newToken = authService.adminLogin(loginReqDto, clientIpResolver.resolve(request));
+        IssuedToken newToken;
+        try {
+            newToken = authService.adminLogin(loginReqDto, clientIpResolver.resolve(request));
+        } catch (UnauthorizedException e) {
+            authAuditLogger.failure(LOGIN_FAILURE, loginReqDto.getUsername(), request, e.getErrorCode().getCode());
+            throw e;
+        }
         addAuthCookies(response, newToken.accessToken(), newToken.refreshToken());
+        authAuditLogger.success(LOGIN_SUCCESS, loginReqDto.getUsername(), request);
         return ResponseEntity.ok().body(tokenMetaResponse());
     }
 
@@ -54,6 +66,7 @@ public class AuthController {
             refreshTokenService.revokeOnLogout(refreshTokenCookie.getValue());
         }
         cookieFactory.expireAuthCookies(response);
+        authAuditLogger.success(LOGOUT, request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -64,7 +77,8 @@ public class AuthController {
             throw new InvalidateTokenException();
         }
         try {
-            return ResponseEntity.ok().body(authService.getTokenInfo(token).getRole());
+            String authority = authService.getTokenInfo(token).getRole();
+            return ResponseEntity.ok().body(Role.fromAuthority(authority).displayName());
         } catch (ExpiredTokenException | InvalidateTokenException | JwtException | IllegalArgumentException e) {
             throw new InvalidateTokenException();
         }
@@ -80,17 +94,12 @@ public class AuthController {
         try {
             ReissuedToken reissuedToken = authService.reissuingAccessToken(refreshTokenCookie.getValue());
             addAuthCookies(response, reissuedToken.accessToken(), reissuedToken.refreshToken());
+            authAuditLogger.success(TOKEN_REISSUE, request);
             return ResponseEntity.ok().body(tokenMetaResponse());
         } catch (InvalidateTokenException | ExpiredRefreshTokenException e) {
             cookieFactory.expireAuthCookies(response);
             throw e;
         }
-    }
-
-    @GetMapping("/api/v1/token-validation")
-    public ResponseEntity<Boolean> tokenValidate(HttpServletRequest request) {
-        String token = tokenResolver.resolve(request);
-        return ResponseEntity.ok().body(token != null && authService.isTokenValid(token));
     }
 
     private void addAuthCookies(HttpServletResponse response, String accessToken, String refreshToken) {

--- a/backend/src/main/java/com/moya/myblogboot/domain/token/Role.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/token/Role.java
@@ -1,5 +1,7 @@
 package com.moya.myblogboot.domain.token;
 
+import java.util.Arrays;
+
 public enum Role {
     ADMIN("ROLE_ADMIN");
 
@@ -11,5 +13,16 @@ public enum Role {
 
     public String getAuthority() {
         return authority;
+    }
+
+    public String displayName() {
+        return name();
+    }
+
+    public static Role fromAuthority(String authority) {
+        return Arrays.stream(values())
+                .filter(role -> role.authority.equals(authority))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown authority: " + authority));
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/dto/auth/LoginReqDto.java
+++ b/backend/src/main/java/com/moya/myblogboot/dto/auth/LoginReqDto.java
@@ -10,10 +10,9 @@ import lombok.*;
 @AllArgsConstructor
 public class LoginReqDto {
     @NotBlank(message = "아이디를 입력하세요.")
-    @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력하여야 합니다.\n※ 공백 및 특수문자 입력 불가능.")
+    @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력하여야 합니다.")
     private String username;
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16 이하로 입력하여야 합니다.\n※ 공백 및 \'!@#$%\'를 제외한 특수문자 입력 불가능")
+    @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16자 이하로 입력하여야 합니다.")
     private String password;
 }
-

--- a/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.moya.myblogboot.exception;
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
+import com.moya.myblogboot.utils.AuthAuditLogger;
 import com.moya.myblogboot.utils.CookieFactory;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +21,27 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.moya.myblogboot.utils.AuthAuditLogger.AuthAuditEvent.LOGIN_LOCKED;
+import static com.moya.myblogboot.utils.AuthAuditLogger.AuthAuditEvent.TOKEN_REISSUE_REUSE_DETECTED;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private static final Set<String> SENSITIVE_FIELDS = Set.of(
+            "password",
+            "oldpassword",
+            "newpassword",
+            "confirmpassword",
+            "token",
+            "secret"
+    );
+
     private final CookieFactory cookieFactory;
+    private final AuthAuditLogger authAuditLogger;
 
     // 비즈니스 예외 — 모든 커스텀 예외를 한 번에 처리
     @ExceptionHandler(BusinessException.class)
@@ -38,9 +54,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(TooManyLoginAttemptsException.class)
-    public ResponseEntity<ErrorResponse> handleTooManyLoginAttempts(TooManyLoginAttemptsException e) {
+    public ResponseEntity<ErrorResponse> handleTooManyLoginAttempts(TooManyLoginAttemptsException e,
+                                                                    HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("Too many login attempts: retryAfterSeconds={}", e.getRetryAfterSeconds());
+        authAuditLogger.failure(LOGIN_LOCKED, request, errorCode.getCode());
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .header(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfterSeconds()))
@@ -62,11 +80,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidateTokenException.class)
     public ResponseEntity<ErrorResponse> handleInvalidateTokenException(
+            HttpServletRequest request,
             HttpServletResponse response,
             InvalidateTokenException e) {
         cookieFactory.expireAuthCookies(response);
         ErrorCode errorCode = e.getErrorCode();
         log.warn("Invalid token: {}", errorCode.getCode());
+        if (errorCode == ErrorCode.REFRESH_TOKEN_REUSE_DETECTED) {
+            authAuditLogger.failure(TOKEN_REISSUE_REUSE_DETECTED, request, errorCode.getCode());
+        }
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
@@ -88,8 +110,7 @@ public class GlobalExceptionHandler {
                 e.getBindingResult().getFieldErrors().stream()
                         .map(error -> ErrorResponse.FieldError.builder()
                                 .field(error.getField())
-                                .value(error.getRejectedValue() != null
-                                        ? error.getRejectedValue().toString() : "")
+                                .value(maskRejectedValue(error.getField(), error.getRejectedValue()))
                                 .reason(error.getDefaultMessage())
                                 .build())
                         .toList();
@@ -132,5 +153,24 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    private String maskRejectedValue(String field, Object rejectedValue) {
+        if (isSensitiveField(field)) {
+            return "[PROTECTED]";
+        }
+        return rejectedValue != null ? rejectedValue.toString() : "";
+    }
+
+    private boolean isSensitiveField(String field) {
+        if (field == null) {
+            return false;
+        }
+        String normalized = field.toLowerCase();
+        int nestedFieldSeparator = normalized.lastIndexOf('.');
+        if (nestedFieldSeparator >= 0) {
+            normalized = normalized.substring(nestedFieldSeparator + 1);
+        }
+        return SENSITIVE_FIELDS.contains(normalized);
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/AuthService.java
@@ -16,6 +16,4 @@ public interface AuthService {
     ReissuedToken reissuingAccessToken(String refreshToken);
 
     TokenInfo getTokenInfo(String token);
-
-    boolean isTokenValid(String token);
 }

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthCredentialVerifier.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthCredentialVerifier.java
@@ -23,11 +23,11 @@ public class AuthCredentialVerifier {
     public Admin verify(LoginReqDto loginReqDto) {
         Admin admin = adminRepository.findByUsername(loginReqDto.getUsername())
                 .orElseThrow(() -> {
-                    log.warn("Admin login failed: username not found");
+                    log.debug("Admin login failed: username not found");
                     return new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
                 });
         if (!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword())) {
-            log.warn("Admin login failed: invalid password");
+            log.debug("Admin login failed: invalid password");
             throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
         }
         return admin;

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/AuthServiceImpl.java
@@ -7,15 +7,12 @@ import com.moya.myblogboot.domain.token.ReissuedToken;
 import com.moya.myblogboot.dto.auth.LoginReqDto;
 import com.moya.myblogboot.domain.login.LoginAttemptResult;
 import com.moya.myblogboot.domain.token.TokenInfo;
-import com.moya.myblogboot.exception.custom.ExpiredTokenException;
-import com.moya.myblogboot.exception.custom.InvalidateTokenException;
 import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
 import com.moya.myblogboot.exception.custom.UnauthorizedException;
 import com.moya.myblogboot.service.AuthService;
 import com.moya.myblogboot.service.LoginAttemptService;
 import com.moya.myblogboot.service.RefreshTokenService;
 import com.moya.myblogboot.utils.JwtTokenProvider;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -60,15 +57,5 @@ public class AuthServiceImpl implements AuthService {
                 .memberPrimaryKey(claims.memberPrimaryKey())
                 .role(claims.role())
                 .build();
-    }
-
-    @Override
-    public boolean isTokenValid(String token) {
-        try {
-            jwtTokenProvider.validateAccessToken(token);
-            return true;
-        } catch (ExpiredTokenException | InvalidateTokenException | JwtException | IllegalArgumentException e) {
-            return false;
-        }
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/RefreshTokenServiceImpl.java
@@ -56,7 +56,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
                 Duration.ofMillis(jwtProperties.absoluteLifetime()).plus(Duration.ofDays(30)),
                 Duration.ofMillis(jwtProperties.refreshTokenExpiration())
         );
-        log.info("Admin login: id={}, family={}", admin.getId(), familyId);
         return new IssuedToken(accessToken, refreshToken);
     }
 
@@ -92,7 +91,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         try {
             RefreshTokenClaims claims = jwtTokenProvider.parseRefreshToken(presentedRefreshToken);
             refreshTokenRedisRepository.revokeFamily(claims.familyId(), Instant.now(), LOGOUT);
-            log.info("Admin logout: family={}", claims.familyId());
         } catch (ExpiredTokenException | InvalidateTokenException e) {
             return;
         }

--- a/backend/src/main/java/com/moya/myblogboot/utils/AuthAuditLogger.java
+++ b/backend/src/main/java/com/moya/myblogboot/utils/AuthAuditLogger.java
@@ -1,0 +1,61 @@
+package com.moya.myblogboot.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthAuditLogger {
+
+    private static final Logger AUDIT = LoggerFactory.getLogger("AUDIT");
+    private static final String UNKNOWN = "unknown";
+
+    private final ClientIpResolver clientIpResolver;
+
+    public AuthAuditLogger(ClientIpResolver clientIpResolver) {
+        this.clientIpResolver = clientIpResolver;
+    }
+
+    public void success(AuthAuditEvent event, String username, HttpServletRequest request) {
+        log(event, "SUCCESS", username, request, "none");
+    }
+
+    public void success(AuthAuditEvent event, HttpServletRequest request) {
+        success(event, UNKNOWN, request);
+    }
+
+    public void failure(AuthAuditEvent event, String username, HttpServletRequest request, String reason) {
+        log(event, "FAILURE", username, request, reason);
+    }
+
+    public void failure(AuthAuditEvent event, HttpServletRequest request, String reason) {
+        failure(event, UNKNOWN, request, reason);
+    }
+
+    private void log(AuthAuditEvent event, String result, String username, HttpServletRequest request, String reason) {
+        AUDIT.info("event={} result={} username={} ip={} ua={} reason={}",
+                event,
+                result,
+                safe(username),
+                safe(clientIpResolver.resolve(request)),
+                safe(request.getHeader("User-Agent")),
+                safe(reason));
+    }
+
+    private String safe(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        return value.replaceAll("\\s+", "_");
+    }
+
+    public enum AuthAuditEvent {
+        LOGIN_SUCCESS,
+        LOGIN_FAILURE,
+        LOGOUT,
+        TOKEN_REISSUE,
+        TOKEN_REISSUE_REUSE_DETECTED,
+        LOGIN_LOCKED
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/controller/AuthControllerTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,6 +36,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -45,7 +51,7 @@ import static com.moya.myblogboot.support.TokenTestSupport.rawRefreshToken;
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
-@ExtendWith(RestDocumentationExtension.class)
+@ExtendWith({RestDocumentationExtension.class, OutputCaptureExtension.class})
 @Import(RestDocsConfiguration.class)
 @ActiveProfiles("test")
 class AuthControllerTest extends AbstractContainerBaseTest {
@@ -144,7 +150,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("ROLE_ADMIN"))
+                .andExpect(MockMvcResultMatchers.content().string("ADMIN"))
                 .andDo(restDocs.document(
                         responseBody()
                 ));
@@ -170,34 +176,6 @@ class AuthControllerTest extends AbstractContainerBaseTest {
                                 fieldWithPath("expiresIn").description("Access Token 만료까지 남은 초")
                         )
                 ));
-    }
-
-    @Test
-    @DisplayName("토큰 만료 확인 테스트")
-    void tokenValidate() throws Exception {
-        String accessToken = getToken().accessToken();
-
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/token-validation")
-                .cookie(new Cookie(ACCESS_TOKEN_COOKIE, accessToken)));
-
-        resultActions
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andDo(restDocs.document(
-                        responseBody()
-                ));
-    }
-
-    @Test
-    @DisplayName("토큰 검증 - 토큰 없음 또는 잘못된 토큰은 false")
-    void tokenValidateWithoutValidCookie() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/token-validation"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("false"));
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/token-validation")
-                        .cookie(new Cookie(ACCESS_TOKEN_COOKIE, "invalid-token")))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("false"));
     }
 
     @Test
@@ -249,7 +227,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 
     @Test
     @DisplayName("로그인 실패 - 잘못된 비밀번호")
-    void loginWithWrongPassword() throws Exception {
+    void loginWithWrongPassword(CapturedOutput output) throws Exception {
         LoginReqDto requestBody = LoginReqDto.builder()
                 .username("testuser")
                 .password("wrongPassword")
@@ -259,11 +237,19 @@ class AuthControllerTest extends AbstractContainerBaseTest {
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        String logs = output.getOut();
+        assertTrue(logs.contains("event=LOGIN_FAILURE"));
+        assertTrue(logs.contains("result=FAILURE"));
+        assertTrue(logs.contains("username=testuser"));
+        assertTrue(logs.contains("ip="));
+        assertTrue(logs.contains("ua="));
+        assertFalse(logs.contains("wrongPassword"));
     }
 
     @Test
     @DisplayName("로그인 실패 5회째부터 429와 Retry-After를 반환한다")
-    void loginBruteForceProtection() throws Exception {
+    void loginBruteForceProtection(CapturedOutput output) throws Exception {
         LoginReqDto requestBody = LoginReqDto.builder()
                 .username("testuser")
                 .password("wrongPassword")
@@ -284,6 +270,30 @@ class AuthControllerTest extends AbstractContainerBaseTest {
                 .andExpect(MockMvcResultMatchers.status().isTooManyRequests())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("A009"))
                 .andExpect(MockMvcResultMatchers.header().exists(HttpHeaders.RETRY_AFTER));
+
+        String logs = output.getOut();
+        assertTrue(logs.contains("event=LOGIN_LOCKED"));
+        assertFalse(logs.contains("event=LOGIN_FAILURE result=FAILURE username=testuser")
+                && logs.lastIndexOf("event=LOGIN_FAILURE result=FAILURE username=testuser")
+                > logs.lastIndexOf("event=LOGIN_LOCKED"));
+        assertFalse(logs.contains("wrongPassword"));
+    }
+
+    @Test
+    @DisplayName("로그인 검증 실패 응답은 민감한 rejectedValue를 마스킹한다")
+    void loginValidationMasksSensitiveRejectedValue() throws Exception {
+        String rawPassword = "too-long-password-value";
+        LoginReqDto requestBody = LoginReqDto.builder()
+                .username("testuser")
+                .password(rawPassword)
+                .build();
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestBody)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.content().string(containsString("[PROTECTED]")))
+                .andExpect(MockMvcResultMatchers.content().string(not(containsString(rawPassword))));
     }
 
     @Test

--- a/backend/src/test/java/com/moya/myblogboot/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/exception/GlobalExceptionHandlerTest.java
@@ -3,21 +3,25 @@ package com.moya.myblogboot.exception;
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.configuration.CookieProperties;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.utils.AuthAuditLogger;
 import com.moya.myblogboot.utils.CookieFactory;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.http.ResponseEntity;
 
 import static com.moya.myblogboot.constants.CookieName.ACCESS_TOKEN_COOKIE;
 import static com.moya.myblogboot.constants.CookieName.REFRESH_TOKEN_COOKIE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class GlobalExceptionHandlerTest {
 
     private final GlobalExceptionHandler exceptionHandler = new GlobalExceptionHandler(
-            new CookieFactory(new CookieProperties(false, "Lax", "", "/"))
+            new CookieFactory(new CookieProperties(false, "Lax", "", "/")),
+            mock(AuthAuditLogger.class)
     );
 
     @Test
@@ -45,6 +49,7 @@ class GlobalExceptionHandlerTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         ResponseEntity<ErrorResponse> result = exceptionHandler.handleInvalidateTokenException(
+                new MockHttpServletRequest(),
                 response,
                 new InvalidateTokenException()
         );

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/AuthServiceImplTest.java
@@ -89,20 +89,6 @@ class AuthServiceImplTest extends AbstractContainerBaseTest {
     }
 
     @Test
-    @DisplayName("유효한 토큰이면 true, 유효하지 않은 토큰이면 false를 반환한다")
-    void isTokenValid() {
-        LoginReqDto loginReqDto = LoginReqDto.builder()
-                .username("testMember")
-                .password("testPassword")
-                .build();
-
-        IssuedToken token = authService.adminLogin(loginReqDto);
-
-        assertTrue(authService.isTokenValid(token.accessToken()));
-        assertFalse(authService.isTokenValid("invalid-token"));
-    }
-
-    @Test
     @DisplayName("임시번호 생성")
     void createTemporaryNumber() {
         String temporaryNumber = String.valueOf(ThreadLocalRandom.current().nextLong());

--- a/frontend/components/management/RoleGate.tsx
+++ b/frontend/components/management/RoleGate.tsx
@@ -40,7 +40,7 @@ export function RoleGate({ children }: { children: React.ReactNode }) {
     );
   }
 
-  if (role !== "ROLE_ADMIN") {
+  if (role !== "ADMIN" && role !== "ROLE_ADMIN") {
     router.replace("/");
     return null;
   }

--- a/frontend/lib/authApi.ts
+++ b/frontend/lib/authApi.ts
@@ -12,15 +12,12 @@ export const login = (formData: { username: string; password: string }) =>
     .then((res) => res.data);
 
 export const logout = () =>
-  axios.get(`${BASE_URL}/api/v1/logout`, { withCredentials: true });
+  axios.post(`${BASE_URL}/api/v1/logout`, undefined, { withCredentials: true });
 
 export const reissuingAccessToken = () =>
   axios
-    .get(`${BASE_URL}/api/v1/reissuing-token`, { withCredentials: true })
+    .post(`${BASE_URL}/api/v1/reissuing-token`, undefined, { withCredentials: true })
     .then((res) => res.data);
-
-export const validateAccessToken = () =>
-  apiClient.get("/api/v1/token-validation").then((res) => res.data);
 
 export const getRoleFromToken = () =>
   apiClient.get("/api/v1/token-role").then((res) => res.data);


### PR DESCRIPTION
  ## Summary

  인증 관련 보안 가시성을 높이고 토큰 API의 의미를 정돈한 리팩터링입니다.

  ### 1. 인증 감사 로깅 도입
  - `AuthAuditLogger` 신설 — `AUDIT` 전용 로거에 구조화된 이벤트 기록
    (`LOGIN_SUCCESS` / `LOGIN_FAILURE` / `LOGOUT` / `TOKEN_REISSUE`
    / `TOKEN_REISSUE_REUSE_DETECTED` / `LOGIN_LOCKED`)
  - 컨트롤러·전역 예외 핸들러에서 이벤트별로 성공/실패 사유, IP, UA 기록

  ### 2. 민감정보 마스킹
  - `GlobalExceptionHandler` — Bean Validation 실패 응답의 `rejectedValue` 중
    `password`/`token`/`secret` 계열 필드를 `[PROTECTED]`로 마스킹
  - `LoginReqDto` — 메시지에서 허용/금지 특수문자 안내 제거(정보 노출 축소)
  - `AuthCredentialVerifier` — 로그인 실패 로그를 `warn` → `debug`로 강등

  ### 3. 토큰 API 계약 정리
  - `GET /api/v1/token-validation` 엔드포인트 및 `AuthService#isTokenValid` 제거
    (`/token-role`로 대체 가능, 미사용 표면 감축)
  - `/api/v1/logout`, `/api/v1/reissuing-token` 메서드 `GET → POST`
    (상태 변경 의미 정합, CSRF 친화)
  - `/token-role` 응답을 `ROLE_ADMIN` → `ADMIN`으로 변경
    (`Role.displayName()` / `Role.fromAuthority()` 도입으로
    내부 권한 표기와 외부 응답 표기 분리)

  ### 4. 프론트엔드 반영
  - `frontend/lib/authApi.ts` — `logout`, `reissuingAccessToken` POST 전환,
    미사용 `validateAccessToken` 제거
  - `RoleGate` — 신/구 응답값(`ADMIN`/`ROLE_ADMIN`) 모두 허용(과도기 호환)

  ## Test plan
  - [ ] `AuthControllerTest` — 로그인 성공/실패 감사 로그(`event=LOGIN_*`),
        비밀번호가 로그에 노출되지 않음, Validation 응답에 `[PROTECTED]` 포함
  - [ ] `AuthControllerTest#loginBruteForceProtection` — `LOGIN_LOCKED` 이벤트 기록
  - [ ] `GlobalExceptionHandlerTest` — `AuthAuditLogger` mock 주입 후 회귀 통과
  - [ ] 수동: 관리자 화면에서 `/token-role`이 `"ADMIN"` 반환해도 `RoleGate` 통과
  - [ ] 수동: logout / reissuing-token POST 전환 후 정상 동작 (쿠키 만료/재발급)

  ## Breaking changes
  - `/api/v1/token-validation` 제거 — 구버전 프론트엔드 호출 시 404
  - `/api/v1/logout`, `/api/v1/reissuing-token` HTTP 메서드 변경 — 구버전 GET 호출 시
  405
  - `/token-role` 응답 본문 변경(`ROLE_ADMIN` → `ADMIN`) — `RoleGate`는 호환 처리됨
