### PR TITLE
fix(backend): 비공개 게시글 공개 접근 차단

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.lettuce:lettuce-core:6.2.6.RELEASE'
+    implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.h2database:h2'
     // Querydsl 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/backend/src/main/java/com/moya/myblogboot/controller/PostController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/PostController.java
@@ -79,13 +79,13 @@ public class PostController {
         boolean valid = postViewCookieService.isValid(cookieValue);
 
         if (!valid || !postViewCookieService.isViewed(cookieValue, postId)) {
-            PostDetailResDto dto = postService.getPostDetailAndIncrementViews(postId);
+            PostDetailResDto dto = postService.getPublicPostDetailAndIncrementViews(postId);
             String newValue = postViewCookieService.addViewed(valid ? cookieValue : null, postId);
             response.addCookie(CookieUtil.addCookie(VIEWED_POSTS, newValue, postViewCookieService.secondsUntilMidnight()));
             return ResponseEntity.ok(dto);
         }
 
-        PostDetailResDto dto = postService.getPostDetail(postId);
+        PostDetailResDto dto = postService.getPublicPostDetail(postId);
         return ResponseEntity.ok()
                 .header("Cache-Control", "public, max-age=60")
                 .body(dto);

--- a/backend/src/main/java/com/moya/myblogboot/controller/PostLikeController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/PostLikeController.java
@@ -74,11 +74,11 @@ public class PostLikeController {
 
     @GetMapping("/api/v1/posts/{postId}/views")
     public ResponseEntity<Long> getViews(@PathVariable("postId") Long postId) {
-        return ResponseEntity.ok().body(postService.getPostDetail(postId).getViews());
+        return ResponseEntity.ok().body(postService.getPublicPostViews(postId));
     }
 
     @GetMapping("/api/v1/posts/{postId}/likes")
     public ResponseEntity<Long> getLikes(@PathVariable("postId") Long postId) {
-        return ResponseEntity.ok().body(postService.getPostDetail(postId).getLikes());
+        return ResponseEntity.ok().body(postService.getPublicPostLikes(postId));
     }
 }

--- a/backend/src/main/java/com/moya/myblogboot/controller/RssFeedController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/RssFeedController.java
@@ -2,6 +2,7 @@ package com.moya.myblogboot.controller;
 
 import com.moya.myblogboot.domain.post.Post;
 import com.moya.myblogboot.repository.PostRepository;
+import com.moya.myblogboot.utils.HtmlTextUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -64,7 +65,7 @@ public class RssFeedController {
             String link = baseUrl + "/posts/" + post.getSlug();
             String description = post.getMetaDescription() != null
                     ? post.getMetaDescription()
-                    : truncate(stripHtml(post.getContent()), 200);
+                    : HtmlTextUtil.summarize(post.getContent(), 200);
 
             sb.append("    <item>\n");
             sb.append("      <title>").append(escapeXml(post.getTitle())).append("</title>\n");
@@ -92,13 +93,4 @@ public class RssFeedController {
                 .replace("'", "&apos;");
     }
 
-    private String stripHtml(String html) {
-        if (html == null) return "";
-        return html.replaceAll("<[^>]+>", "").trim();
-    }
-
-    private String truncate(String text, int maxLength) {
-        if (text == null || text.length() <= maxLength) return text;
-        return text.substring(0, maxLength) + "...";
-    }
 }

--- a/backend/src/main/java/com/moya/myblogboot/dto/post/PostReqDto.java
+++ b/backend/src/main/java/com/moya/myblogboot/dto/post/PostReqDto.java
@@ -25,18 +25,23 @@ public class PostReqDto {
     private Long category;
     private List<ImageFileDto> images;
     private String slug;
+    @Size(max = 160, message = "메타 설명은 160자 이하로 작성해야합니다.")
     private String metaDescription;
     private String metaKeywords;
     private String thumbnailUrl;
 
     public Post toEntity(Category category, Admin admin, String resolvedSlug) {
+        return toEntity(category, admin, resolvedSlug, this.metaDescription);
+    }
+
+    public Post toEntity(Category category, Admin admin, String resolvedSlug, String resolvedMetaDescription) {
         return Post.builder()
                 .admin(admin)
                 .category(category)
                 .title(this.title)
                 .content(this.content)
                 .slug(resolvedSlug)
-                .metaDescription(this.metaDescription)
+                .metaDescription(resolvedMetaDescription)
                 .metaKeywords(this.metaKeywords)
                 .thumbnailUrl(this.thumbnailUrl)
                 .build();

--- a/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "B002", "게시글 수정/삭제 권한이 없습니다."),
     DUPLICATE_POST_LIKE(HttpStatus.CONFLICT, "B003", "이미 좋아요한 게시글입니다."),
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "B004", "좋아요하지 않은 게시글입니다."),
+    POST_GONE(HttpStatus.GONE, "B005", "삭제된 게시글입니다."),
 
     // 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM001", "해당 댓글이 존재하지 않습니다."),

--- a/backend/src/main/java/com/moya/myblogboot/exception/custom/PostGoneException.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/custom/PostGoneException.java
@@ -1,0 +1,10 @@
+package com.moya.myblogboot.exception.custom;
+
+import com.moya.myblogboot.exception.BusinessException;
+import com.moya.myblogboot.exception.ErrorCode;
+
+public class PostGoneException extends BusinessException {
+    public PostGoneException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/repository/PostRepository.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/PostRepository.java
@@ -26,13 +26,14 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostQuerydslR
             "join fetch p.category where p.id = :postId")
     Optional<Post> findById(@Param("postId") Long postId);
 
-    @Query(value = "select p from Post p join fetch p.admin join fetch p.category where p.postStatus = :postStatus",
-            countQuery = "select count(p) from Post p where p.postStatus = :postStatus")
+    @Query(value = "select p from Post p join fetch p.admin join fetch p.category " +
+            "where p.postStatus = :postStatus and p.deleteDate is null",
+            countQuery = "select count(p) from Post p where p.postStatus = :postStatus and p.deleteDate is null")
     Page<Post> findAll(@Param("postStatus") PostStatus postStatus, Pageable pageable);
 
     @Query(value = "select p from Post p join fetch p.admin join fetch p.category " +
-            "where p.category.name = :categoryName and p.postStatus = 'VIEW'",
-            countQuery = "select count(p) from Post p where p.category.name = :categoryName and p.postStatus = 'VIEW'")
+            "where p.category.name = :categoryName and p.postStatus = 'VIEW' and p.deleteDate is null",
+            countQuery = "select count(p) from Post p where p.category.name = :categoryName and p.postStatus = 'VIEW' and p.deleteDate is null")
     Page<Post> findAllByCategoryName(@Param("categoryName") String categoryName, PageRequest pageRequest);
 
     @Query(value = "select p from Post p join fetch p.admin join fetch p.category " +
@@ -43,15 +44,15 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostQuerydslR
     // Next.js sitemap/generateStaticParams 전용: slug + updateDate만 조회 (content 제외)
     @Query("select new com.moya.myblogboot.dto.post.PostSlugDto(p.slug, p.updateDate) " +
             "from Post p " +
-            "where p.postStatus = 'VIEW' and p.slug is not null " +
+            "where p.postStatus = 'VIEW' and p.deleteDate is null and p.slug is not null " +
             "order by p.updateDate desc")
     List<PostSlugDto> findAllSlugs();
 
     // RSS 피드 전용: 최근 VIEW 게시글 (category fetch join)
     @Query(value = "select p from Post p " +
             "join fetch p.category " +
-            "where p.postStatus = 'VIEW' and p.slug is not null " +
+            "where p.postStatus = 'VIEW' and p.deleteDate is null and p.slug is not null " +
             "order by p.createDate desc",
-            countQuery = "select count(p) from Post p where p.postStatus = 'VIEW'")
+            countQuery = "select count(p) from Post p where p.postStatus = 'VIEW' and p.deleteDate is null")
     Page<Post> findRecentForRss(Pageable pageable);
 }

--- a/backend/src/main/java/com/moya/myblogboot/repository/implementation/PostQuerydslRepositoryImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/implementation/PostQuerydslRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.moya.myblogboot.repository.implementation;
 
 import com.moya.myblogboot.domain.post.Post;
+import com.moya.myblogboot.domain.post.PostStatus;
 import com.moya.myblogboot.domain.post.SearchType;
 import com.moya.myblogboot.repository.PostQuerydslRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -34,6 +35,9 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
         BooleanExpression condition = searchType == SearchType.TITLE
                 ? post.title.contains(contents)
                 : post.content.contains(contents);
+        condition = condition
+                .and(post.postStatus.eq(PostStatus.VIEW))
+                .and(post.deleteDate.isNull());
 
         List<Post> posts = queryFactory.selectFrom(post)
                 .join(post.admin).fetchJoin()

--- a/backend/src/main/java/com/moya/myblogboot/service/PostService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/PostService.java
@@ -24,6 +24,14 @@ public interface PostService {
 
     PostDetailResDto getPostDetailAndIncrementViews(Long postId);
 
+    PostDetailResDto getPublicPostDetail(Long postId);
+
+    PostDetailResDto getPublicPostDetailAndIncrementViews(Long postId);
+
+    Long getPublicPostViews(Long postId);
+
+    Long getPublicPostLikes(Long postId);
+
     Long getPostIdBySlug(String slug);
 
     List<PostSlugDto> getAllSlugs();

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/PostServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/PostServiceImpl.java
@@ -10,6 +10,7 @@ import com.moya.myblogboot.domain.post.SearchType;
 import com.moya.myblogboot.dto.post.*;
 import com.moya.myblogboot.exception.ErrorCode;
 import com.moya.myblogboot.exception.custom.EntityNotFoundException;
+import com.moya.myblogboot.exception.custom.PostGoneException;
 import com.moya.myblogboot.exception.custom.UnauthorizedAccessException;
 import com.moya.myblogboot.repository.AdminRepository;
 import com.moya.myblogboot.repository.ImageFileRepository;
@@ -92,13 +93,45 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    public PostDetailResDto getPublicPostDetail(Long postId) {
+        PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
+        assertPubliclyViewable(postForRedis);
+        return PostDetailResDto.builder()
+                .postForRedis(postForRedis)
+                .build();
+    }
+
+    @Override
+    public PostDetailResDto getPublicPostDetailAndIncrementViews(Long postId) {
+        PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
+        assertPubliclyViewable(postForRedis);
+        return PostDetailResDto.builder()
+                .postForRedis(postRedisRepository.incrementViews(postForRedis))
+                .build();
+    }
+
+    @Override
+    public Long getPublicPostViews(Long postId) {
+        PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
+        assertPubliclyViewable(postForRedis);
+        return postForRedis.totalViews();
+    }
+
+    @Override
+    public Long getPublicPostLikes(Long postId) {
+        PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
+        assertPubliclyViewable(postForRedis);
+        return postForRedis.totalLikes();
+    }
+
+    @Override
     @Transactional
     public Long write(PostReqDto postReqDto, Long adminId) {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         Category category = categoryService.retrieve(postReqDto.getCategory());
         String slug = resolveSlug(postReqDto.getSlug(), postReqDto.getTitle(), null);
-        Post newPost = postReqDto.toEntity(category, admin, slug);
+        Post newPost = postReqDto.toEntity(category, admin, slug, resolveMetaDescription(postReqDto));
         if (postReqDto.getImages() != null && !postReqDto.getImages().isEmpty()) {
             saveImageFile(postReqDto.getImages(), newPost);
         }
@@ -116,7 +149,7 @@ public class PostServiceImpl implements PostService {
         Category modifiedCategory = categoryService.retrieve(modifiedDto.getCategory());
         String slug = resolveSlug(modifiedDto.getSlug(), modifiedDto.getTitle(), post.getSlug());
         post.updatePost(modifiedCategory, modifiedDto.getTitle(), modifiedDto.getContent(),
-                slug, modifiedDto.getMetaDescription(), modifiedDto.getMetaKeywords(), modifiedDto.getThumbnailUrl());
+                slug, resolveMetaDescription(modifiedDto), modifiedDto.getMetaKeywords(), modifiedDto.getThumbnailUrl());
         postCacheService.updatePost(postCacheService.getPostFromCache(post.getId()), post);
         eventPublisher.publishEvent(new PostChangeEvent(this, "UPDATED", postId, post.getSlug()));
         return postId;
@@ -183,6 +216,22 @@ public class PostServiceImpl implements PostService {
     private void verifyPostAccessAuthorization(Long postAdminId, Long adminId) {
         if (!postAdminId.equals(adminId))
             throw new UnauthorizedAccessException(ErrorCode.POST_ACCESS_DENIED);
+    }
+
+    private void assertPubliclyViewable(PostForRedis postForRedis) {
+        if (postForRedis.getDeleteDate() != null) {
+            throw new PostGoneException(ErrorCode.POST_GONE);
+        }
+        if (postForRedis.getPostStatus() != PostStatus.VIEW) {
+            throw new EntityNotFoundException(ErrorCode.POST_NOT_FOUND);
+        }
+    }
+
+    private String resolveMetaDescription(PostReqDto postReqDto) {
+        if (postReqDto.getMetaDescription() == null || postReqDto.getMetaDescription().isBlank()) {
+            return com.moya.myblogboot.utils.HtmlTextUtil.summarize(postReqDto.getContent(), 155);
+        }
+        return postReqDto.getMetaDescription();
     }
 
     private void deletePosts(Post post) {

--- a/backend/src/main/java/com/moya/myblogboot/utils/HtmlTextUtil.java
+++ b/backend/src/main/java/com/moya/myblogboot/utils/HtmlTextUtil.java
@@ -1,0 +1,23 @@
+package com.moya.myblogboot.utils;
+
+import org.jsoup.Jsoup;
+
+public final class HtmlTextUtil {
+    private HtmlTextUtil() {
+    }
+
+    public static String toPlainText(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        return Jsoup.parse(html).text().trim();
+    }
+
+    public static String summarize(String html, int maxLength) {
+        String text = toPlainText(html);
+        if (text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength).trim() + "...";
+    }
+}

--- a/backend/src/test/java/com/moya/myblogboot/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/controller/PostControllerTest.java
@@ -6,6 +6,7 @@ import com.moya.myblogboot.config.RestDocsConfiguration;
 import com.moya.myblogboot.constants.CookieName;
 import com.moya.myblogboot.domain.admin.Admin;
 import com.moya.myblogboot.domain.post.Post;
+import com.moya.myblogboot.domain.post.PostStatus;
 import com.moya.myblogboot.dto.post.PostReqDto;
 import com.moya.myblogboot.domain.post.SearchType;
 import com.moya.myblogboot.domain.category.Category;
@@ -115,7 +116,7 @@ class PostControllerTest extends AbstractContainerBaseTest {
                 .password("testPassword")
                 .build();
 
-        accessToken = "bearer " + authService.adminLogin(loginReqDto).accessToken();
+        accessToken = authService.adminLogin(loginReqDto).accessToken();
     }
 
     @Test
@@ -218,6 +219,35 @@ class PostControllerTest extends AbstractContainerBaseTest {
     }
 
     @Test
+    @DisplayName("검색 결과별 게시글 조회 - HIDE 및 삭제 게시글 제외")
+    void getSearchedPosts_excludesHiddenAndDeletedPosts() throws Exception {
+        Post hiddenPost = postRepository.save(Post.builder()
+                .admin(adminRepository.findAll().get(0))
+                .category(categoryRepository.findById(categoryId).orElseThrow())
+                .title("private searchable title")
+                .content("private searchable content")
+                .slug("private-searchable-title")
+                .build());
+        hiddenPost.updatePostStatus(PostStatus.HIDE);
+
+        Post deletedPost = postRepository.save(Post.builder()
+                .admin(adminRepository.findAll().get(0))
+                .category(categoryRepository.findById(categoryId).orElseThrow())
+                .title("deleted searchable title")
+                .content("deleted searchable content")
+                .slug("deleted-searchable-title")
+                .build());
+        deletedPost.delete();
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/search")
+                        .param("p", "1")
+                        .param("type", String.valueOf(SearchType.TITLE))
+                        .param("contents", "searchable"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.list.length()").value(0));
+    }
+
+    @Test
     @DisplayName("게시글 상세 조회 V1 (slug) — 최초 조회: 조회수 증가 + viewed_posts 쿠키 발급")
     void getPostDetailV1BySlug_최초조회() throws Exception {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug));
@@ -310,10 +340,66 @@ class PostControllerTest extends AbstractContainerBaseTest {
     }
 
     @Test
+    @DisplayName("게시글 상세 조회 V1 - HIDE 게시글은 404")
+    void getPostDetailV1HiddenPostReturns404() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.updatePostStatus(PostStatus.HIDE);
+
+        mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회 V1 - 삭제 게시글은 410")
+    void getPostDetailV1DeletedPostReturns410() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.deletePost();
+
+        mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug))
+                .andExpect(MockMvcResultMatchers.status().isGone())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("B005"));
+    }
+
+    @Test
+    @DisplayName("게시글 상세 관리자용 - 삭제 게시글도 조회 가능")
+    void getPostDetailForAdminCanReadDeletedPost() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.deletePost();
+
+        mockMvc.perform(get("/api/v1/management/posts/{postId}", postId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(postId));
+    }
+
+    @Test
+    @DisplayName("게시글 조회수 조회 - 삭제 게시글은 410")
+    void getViewsDeletedPostReturns410() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.deletePost();
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/views", postId))
+                .andExpect(MockMvcResultMatchers.status().isGone())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("B005"));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 수 조회 - HIDE 게시글은 404")
+    void getLikesHiddenPostReturns404() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.updatePostStatus(PostStatus.HIDE);
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/likes", postId))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
     @DisplayName("게시글 상세 관리자용")
     void getPostDetailForAdmin() throws Exception {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/management/posts/{postId}", postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -352,6 +438,7 @@ class PostControllerTest extends AbstractContainerBaseTest {
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post(path)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken))
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(postReqDto)));
 
@@ -386,6 +473,7 @@ class PostControllerTest extends AbstractContainerBaseTest {
 
         ResultActions resultActions = mockMvc.perform(put("/api/v1/posts/{postId}", postId)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken))
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(modifiedPostDto)));
 
@@ -416,7 +504,8 @@ class PostControllerTest extends AbstractContainerBaseTest {
     @DisplayName("게시글 삭제")
     void deletePost() throws Exception {
         ResultActions resultActions = mockMvc.perform(delete("/api/v1/posts/{postId}", postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -434,12 +523,14 @@ class PostControllerTest extends AbstractContainerBaseTest {
     @DisplayName("삭제 예정 게시글 리스트")
     void getDeletedPosts() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/" + postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
         String path = "/api/v1/deleted-posts";
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(path)
                 .param("p", "1")
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -458,10 +549,12 @@ class PostControllerTest extends AbstractContainerBaseTest {
     void cancelDeletedPost() throws Exception {
         // 먼저 삭제 요청
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/" + postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         ResultActions resultActions = mockMvc.perform(put("/api/v1/deleted-posts/{postId}", postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -480,10 +573,12 @@ class PostControllerTest extends AbstractContainerBaseTest {
     void deletePostPermanently() throws Exception {
         // 먼저 삭제(soft-delete) 처리 후 영구 삭제
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/" + postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         ResultActions resultActions = mockMvc.perform(delete("/api/v1/deleted-posts/{postId}", postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -549,7 +644,7 @@ class PostControllerTest extends AbstractContainerBaseTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(postReqDto)))
-                .andExpect(MockMvcResultMatchers.status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test
@@ -563,6 +658,25 @@ class PostControllerTest extends AbstractContainerBaseTest {
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts")
                         .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(postReqDto)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("게시글 등록 실패 - metaDescription 160자 초과")
+    void writePostWithTooLongMetaDescription() throws Exception {
+        PostReqDto postReqDto = PostReqDto.builder()
+                .category(categoryId)
+                .title("title")
+                .content("content")
+                .metaDescription("a".repeat(161))
+                .build();
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken))
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(postReqDto)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest());
@@ -592,11 +706,23 @@ class PostControllerTest extends AbstractContainerBaseTest {
     void getAllSlugs_excludesHiddenPosts() throws Exception {
         // 게시글 하나를 HIDE로 변경
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/" + postId)
-                .header(HttpHeaders.AUTHORIZATION, accessToken));
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)));
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/slugs"));
 
         resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(4));
+    }
+
+    @Test
+    @DisplayName("전체 Slug 목록 조회 - VIEW 상태라도 deleteDate가 있으면 제외")
+    void getAllSlugs_excludesDeletedDatePosts() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.delete();
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/slugs"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(4));
     }

--- a/backend/src/test/java/com/moya/myblogboot/service/implementation/PostServiceImplTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/service/implementation/PostServiceImplTest.java
@@ -99,6 +99,37 @@ class PostServiceImplTest extends AbstractContainerBaseTest {
     }
 
     @Test
+    @DisplayName("게시글 작성 - metaDescription이 blank면 HTML 본문에서 자동 생성")
+    void write_generatesMetaDescriptionFromContentWhenBlank() {
+        PostReqDto reqDto = PostReqDto.builder()
+                .title("새 게시글")
+                .content("<p>Hello <strong>SEO</strong> &amp; blog</p><script>alert('x')</script>")
+                .category(testCategory.getId())
+                .metaDescription(" ")
+                .build();
+
+        Long postId = postService.write(reqDto, testAdmin.getId());
+
+        Post savedPost = postRepository.findById(postId).orElseThrow();
+        assertThat(savedPost.getMetaDescription()).isEqualTo("Hello SEO & blog");
+    }
+
+    @Test
+    @DisplayName("게시글 수정 - metaDescription이 blank면 HTML 본문에서 자동 생성")
+    void edit_generatesMetaDescriptionFromContentWhenBlank() {
+        PostReqDto modifiedDto = PostReqDto.builder()
+                .title("수정된 제목")
+                .content("<h1>Updated</h1><p>description text</p>")
+                .category(testCategory.getId())
+                .metaDescription("")
+                .build();
+
+        postService.edit(testAdmin.getId(), testPost.getId(), modifiedDto);
+
+        assertThat(testPost.getMetaDescription()).isEqualTo("Updated description text");
+    }
+
+    @Test
     @DisplayName("게시글 작성 실패 - 존재하지 않는 카테고리")
     void write_invalidCategory() {
         PostReqDto reqDto = PostReqDto.builder()


### PR DESCRIPTION
 ## Summary
  - 공개 상세 API와 views/likes 숫자 조회 API에 게시글 공개 상태 가드를 추가했습니다.
  - 삭제된 게시글은 404가 아닌 410 Gone(`B005`)으로 응답하도록 분리했습니다.
  - 검색, 목록, 카테고리, slug, RSS 공개 쿼리에서 `deleteDate is null` 조건을 명시했습
  니다.
  - `metaDescription` 길이 검증과 blank 입력 시 HTML 본문 기반 자동 생성을 추가했습니
  다.
  - RSS description 추출 로직을 Jsoup 기반 공용 유틸로 정리했습니다.

  ## 접근 차단 이유
  비공개(HIDE) 또는 삭제된 게시글이 공개 API를 통해 본문/존재 신호를 노출할 수 있던 문
  제를 차단하기 위함입니다. SEO 관점에서는 삭제 글을 410으로 분리해 프론트에서 검색엔진
  에 명확한 제거 신호를 표면화할 수 있도록 했습니다.

  ## 변경 내용
  - `PostService`에 공개 전용 조회 메서드 추가
  - `PostGoneException`, `POST_GONE(B005)` 추가
  - 공개 상세/조회수/좋아요 수 API에 `VIEW && deleteDate == null` 가드 적용
  - 검색 및 공개 목록성 쿼리에 삭제 글 제외 조건 추가
  - `PostReqDto.metaDescription`에 `@Size(max = 160)` 추가
  - `HtmlTextUtil` 추가 및 RSS fallback description 공용화
  - Jsoup 의존성 추가
  - 공개 접근/삭제 응답/metaDescription 회귀 테스트 추가