### PR TITLE
feat(backend): 게시글 slug 리다이렉트와 조회수 증가 API 분리

### DIFF
--- a/backend/src/main/java/com/moya/myblogboot/controller/PostController.java
+++ b/backend/src/main/java/com/moya/myblogboot/controller/PostController.java
@@ -69,26 +69,30 @@ public class PostController {
 
     // slug 또는 숫자 ID 모두 처리 — HMAC 쿠키로 중복 조회 방지
     @GetMapping("/api/v1/posts/{identifier}")
-    public ResponseEntity<PostDetailResDto> getPostDetail(@PathVariable("identifier") String identifier,
-                                                          HttpServletRequest request,
-                                                          HttpServletResponse response) {
-        Long postId = resolvePostId(identifier);
+    public ResponseEntity<PostDetailResDto> getPostDetail(@PathVariable("identifier") String identifier) {
+        PostDetailResDto dto = postService.getPublicPostDetail(identifier);
+        return ResponseEntity.ok()
+                .header("Cache-Control", "public, max-age=60")
+                .body(dto);
+    }
 
+    @PostMapping("/api/v1/posts/{postId}/views")
+    public ResponseEntity<Long> incrementPostViews(@PathVariable("postId") Long postId,
+                                                   HttpServletRequest request,
+                                                   HttpServletResponse response) {
         Cookie cookie = CookieUtil.findCookie(request, VIEWED_POSTS);
         String cookieValue = (cookie != null) ? cookie.getValue() : null;
         boolean valid = postViewCookieService.isValid(cookieValue);
 
+        Long totalViews;
         if (!valid || !postViewCookieService.isViewed(cookieValue, postId)) {
-            PostDetailResDto dto = postService.getPublicPostDetailAndIncrementViews(postId);
+            totalViews = postService.incrementPublicPostViews(postId);
             String newValue = postViewCookieService.addViewed(valid ? cookieValue : null, postId);
             response.addCookie(CookieUtil.addCookie(VIEWED_POSTS, newValue, postViewCookieService.secondsUntilMidnight()));
-            return ResponseEntity.ok(dto);
+        } else {
+            totalViews = postService.getPublicPostViews(postId);
         }
-
-        PostDetailResDto dto = postService.getPublicPostDetail(postId);
-        return ResponseEntity.ok()
-                .header("Cache-Control", "public, max-age=60")
-                .body(dto);
+        return ResponseEntity.ok(totalViews);
     }
 
     // v8 → v1 301 redirect (하위 호환)
@@ -129,14 +133,6 @@ public class PostController {
         Long memberId = PrincipalUtil.getMemberId(principal);
         postService.delete(postId, memberId);
         return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    private Long resolvePostId(String identifier) {
-        try {
-            return Long.parseLong(identifier);
-        } catch (NumberFormatException e) {
-            return postService.getPostIdBySlug(identifier);
-        }
     }
 
     private int getPage(int page) {

--- a/backend/src/main/java/com/moya/myblogboot/domain/post/PostSlugHistory.java
+++ b/backend/src/main/java/com/moya/myblogboot/domain/post/PostSlugHistory.java
@@ -1,0 +1,40 @@
+package com.moya.myblogboot.domain.post;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post_slug_history",
+        indexes = {
+                @Index(name = "uk_slug_history_old_slug", columnList = "old_slug", unique = true),
+                @Index(name = "ix_slug_history_post_id", columnList = "post_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostSlugHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_slug_history_post"))
+    private Post post;
+
+    @Column(name = "old_slug", nullable = false, length = 255, unique = true)
+    private String oldSlug;
+
+    @Column(name = "changed_at", nullable = false)
+    private LocalDateTime changedAt;
+
+    public PostSlugHistory(Post post, String oldSlug) {
+        this.post = post;
+        this.oldSlug = oldSlug;
+        this.changedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     DUPLICATE_POST_LIKE(HttpStatus.CONFLICT, "B003", "이미 좋아요한 게시글입니다."),
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "B004", "좋아요하지 않은 게시글입니다."),
     POST_GONE(HttpStatus.GONE, "B005", "삭제된 게시글입니다."),
+    DUPLICATE_POST_SLUG(HttpStatus.CONFLICT, "B006", "이미 사용 중인 게시글 슬러그입니다."),
 
     // 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM001", "해당 댓글이 존재하지 않습니다."),

--- a/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.moya.myblogboot.exception;
 
 import com.moya.myblogboot.exception.custom.ExpiredRefreshTokenException;
 import com.moya.myblogboot.exception.custom.InvalidateTokenException;
+import com.moya.myblogboot.exception.custom.PostMovedPermanentlyException;
 import com.moya.myblogboot.exception.custom.TooManyLoginAttemptsException;
 import com.moya.myblogboot.utils.AuthAuditLogger;
 import com.moya.myblogboot.utils.CookieFactory;
@@ -9,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -42,6 +44,18 @@ public class GlobalExceptionHandler {
 
     private final CookieFactory cookieFactory;
     private final AuthAuditLogger authAuditLogger;
+
+    @Value("${app.base-url}")
+    private String appBaseUrl;
+
+    @ExceptionHandler(PostMovedPermanentlyException.class)
+    public ResponseEntity<Void> handlePostMovedPermanently(PostMovedPermanentlyException e) {
+        String baseUrl = appBaseUrl.endsWith("/") ? appBaseUrl.substring(0, appBaseUrl.length() - 1) : appBaseUrl;
+        return ResponseEntity
+                .status(HttpStatus.MOVED_PERMANENTLY)
+                .header(HttpHeaders.LOCATION, baseUrl + "/posts/" + e.getCurrentSlug())
+                .build();
+    }
 
     // 비즈니스 예외 — 모든 커스텀 예외를 한 번에 처리
     @ExceptionHandler(BusinessException.class)

--- a/backend/src/main/java/com/moya/myblogboot/exception/custom/PostMovedPermanentlyException.java
+++ b/backend/src/main/java/com/moya/myblogboot/exception/custom/PostMovedPermanentlyException.java
@@ -1,0 +1,14 @@
+package com.moya.myblogboot.exception.custom;
+
+import lombok.Getter;
+
+@Getter
+public class PostMovedPermanentlyException extends RuntimeException {
+
+    private final String currentSlug;
+
+    public PostMovedPermanentlyException(String currentSlug) {
+        super("Post moved permanently to slug: " + currentSlug);
+        this.currentSlug = currentSlug;
+    }
+}

--- a/backend/src/main/java/com/moya/myblogboot/repository/PostSlugHistoryRepository.java
+++ b/backend/src/main/java/com/moya/myblogboot/repository/PostSlugHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.moya.myblogboot.repository;
+
+import com.moya.myblogboot.domain.post.PostSlugHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostSlugHistoryRepository extends JpaRepository<PostSlugHistory, Long> {
+
+    Optional<PostSlugHistory> findByOldSlug(String oldSlug);
+
+    boolean existsByOldSlug(String oldSlug);
+}

--- a/backend/src/main/java/com/moya/myblogboot/service/PostService.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/PostService.java
@@ -22,11 +22,13 @@ public interface PostService {
 
     PostDetailResDto getPostDetail(Long postId);
 
-    PostDetailResDto getPostDetailAndIncrementViews(Long postId);
-
     PostDetailResDto getPublicPostDetail(Long postId);
 
-    PostDetailResDto getPublicPostDetailAndIncrementViews(Long postId);
+    PostDetailResDto getPublicPostDetail(String identifier);
+
+    Long incrementPublicPostViews(Long postId);
+
+    void assertPubliclyViewable(Long postId);
 
     Long getPublicPostViews(Long postId);
 

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/PostLikeServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/PostLikeServiceImpl.java
@@ -4,6 +4,7 @@ import com.moya.myblogboot.dto.post.PostForRedis;
 import com.moya.myblogboot.repository.PostRedisRepository;
 import com.moya.myblogboot.service.PostCacheService;
 import com.moya.myblogboot.service.PostLikeService;
+import com.moya.myblogboot.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,15 +14,18 @@ public class PostLikeServiceImpl implements PostLikeService {
 
     private final PostCacheService postCacheService;
     private final PostRedisRepository postRedisRepository;
+    private final PostService postService;
 
     @Override
     public Long addLikes(Long postId) {
+        postService.assertPubliclyViewable(postId);
         PostForRedis post = postCacheService.getPostFromCache(postId);
         return postRedisRepository.incrementLikes(post).totalLikes();
     }
 
     @Override
     public Long cancelLikes(Long postId) {
+        postService.assertPubliclyViewable(postId);
         PostForRedis post = postCacheService.getPostFromCache(postId);
         return postRedisRepository.decrementLikes(post).totalLikes();
     }

--- a/backend/src/main/java/com/moya/myblogboot/service/implementation/PostServiceImpl.java
+++ b/backend/src/main/java/com/moya/myblogboot/service/implementation/PostServiceImpl.java
@@ -5,17 +5,21 @@ import com.moya.myblogboot.domain.category.Category;
 import com.moya.myblogboot.domain.file.ImageFile;
 import com.moya.myblogboot.dto.file.ImageFileDto;
 import com.moya.myblogboot.domain.post.Post;
+import com.moya.myblogboot.domain.post.PostSlugHistory;
 import com.moya.myblogboot.domain.post.PostStatus;
 import com.moya.myblogboot.domain.post.SearchType;
 import com.moya.myblogboot.dto.post.*;
 import com.moya.myblogboot.exception.ErrorCode;
+import com.moya.myblogboot.exception.custom.DuplicateException;
 import com.moya.myblogboot.exception.custom.EntityNotFoundException;
 import com.moya.myblogboot.exception.custom.PostGoneException;
+import com.moya.myblogboot.exception.custom.PostMovedPermanentlyException;
 import com.moya.myblogboot.exception.custom.UnauthorizedAccessException;
 import com.moya.myblogboot.repository.AdminRepository;
 import com.moya.myblogboot.repository.ImageFileRepository;
 import com.moya.myblogboot.repository.PostRedisRepository;
 import com.moya.myblogboot.repository.PostRepository;
+import com.moya.myblogboot.repository.PostSlugHistoryRepository;
 import com.moya.myblogboot.service.CategoryService;
 import com.moya.myblogboot.service.FileUploadService;
 import com.moya.myblogboot.service.PostCacheService;
@@ -47,6 +51,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final ImageFileRepository imageFileRepository;
     private final PostRedisRepository postRedisRepository;
+    private final PostSlugHistoryRepository postSlugHistoryRepository;
     private final FileUploadService fileUploadService;
     private final PostCacheService postCacheService;
     private final ApplicationEventPublisher eventPublisher;
@@ -85,14 +90,6 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostDetailResDto getPostDetailAndIncrementViews(Long postId) {
-        PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
-        return PostDetailResDto.builder()
-                .postForRedis(postRedisRepository.incrementViews(postForRedis))
-                .build();
-    }
-
-    @Override
     public PostDetailResDto getPublicPostDetail(Long postId) {
         PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
         assertPubliclyViewable(postForRedis);
@@ -102,12 +99,20 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostDetailResDto getPublicPostDetailAndIncrementViews(Long postId) {
+    public PostDetailResDto getPublicPostDetail(String identifier) {
+        return getPublicPostDetail(resolvePublicPostId(identifier));
+    }
+
+    @Override
+    public Long incrementPublicPostViews(Long postId) {
         PostForRedis postForRedis = postCacheService.getPostFromCache(postId);
         assertPubliclyViewable(postForRedis);
-        return PostDetailResDto.builder()
-                .postForRedis(postRedisRepository.incrementViews(postForRedis))
-                .build();
+        return postRedisRepository.incrementViews(postForRedis).totalViews();
+    }
+
+    @Override
+    public void assertPubliclyViewable(Long postId) {
+        assertPubliclyViewable(postCacheService.getPostFromCache(postId));
     }
 
     @Override
@@ -147,9 +152,11 @@ public class PostServiceImpl implements PostService {
         Post post = findById(postId);
         verifyPostAccessAuthorization(post.getAdmin().getId(), adminId);
         Category modifiedCategory = categoryService.retrieve(modifiedDto.getCategory());
-        String slug = resolveSlug(modifiedDto.getSlug(), modifiedDto.getTitle(), post.getSlug());
+        String oldSlug = post.getSlug();
+        String slug = resolveSlug(modifiedDto.getSlug(), modifiedDto.getTitle(), post);
         post.updatePost(modifiedCategory, modifiedDto.getTitle(), modifiedDto.getContent(),
                 slug, resolveMetaDescription(modifiedDto), modifiedDto.getMetaKeywords(), modifiedDto.getThumbnailUrl());
+        recordSlugHistoryIfChanged(post, oldSlug, slug);
         postCacheService.updatePost(postCacheService.getPostFromCache(post.getId()), post);
         eventPublisher.publishEvent(new PostChangeEvent(this, "UPDATED", postId, post.getSlug()));
         return postId;
@@ -234,6 +241,23 @@ public class PostServiceImpl implements PostService {
         return postReqDto.getMetaDescription();
     }
 
+    private Long resolvePublicPostId(String identifier) {
+        try {
+            return Long.parseLong(identifier);
+        } catch (NumberFormatException e) {
+            return postRepository.findIdBySlug(identifier)
+                    .orElseGet(() -> resolveMovedPostByOldSlug(identifier));
+        }
+    }
+
+    private Long resolveMovedPostByOldSlug(String oldSlug) {
+        PostSlugHistory history = postSlugHistoryRepository.findByOldSlug(oldSlug)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        PostForRedis target = postCacheService.getPostFromCache(history.getPost().getId());
+        assertPubliclyViewable(target);
+        throw new PostMovedPermanentlyException(target.getSlug());
+    }
+
     private void deletePosts(Post post) {
         PostForRedis postForRedis = postCacheService.getPostFromCache(post.getId());
         fileUploadService.deleteFiles(post.getImageFiles());
@@ -254,10 +278,13 @@ public class PostServiceImpl implements PostService {
      * 2. 기존 slug가 있으면 유지 (수정 시)
      * 3. 없으면 title에서 자동 생성
      */
-    private String resolveSlug(String requestedSlug, String title, String existingSlug) {
+    private String resolveSlug(String requestedSlug, String title, Post existingPost) {
+        String existingSlug = existingPost != null ? existingPost.getSlug() : null;
+        Long existingPostId = existingPost != null ? existingPost.getId() : null;
         if (requestedSlug != null && !requestedSlug.isBlank()) {
             if (requestedSlug.equals(existingSlug)) return existingSlug;
-            if (!postRepository.existsBySlug(requestedSlug)) return requestedSlug;
+            assertSlugAvailable(requestedSlug, existingPostId);
+            return requestedSlug;
         }
         if (existingSlug != null) return existingSlug;
         return generateUniqueSlug(title);
@@ -265,11 +292,39 @@ public class PostServiceImpl implements PostService {
 
     private String generateUniqueSlug(String title) {
         String base = SlugUtil.generate(title);
-        if (!postRepository.existsBySlug(base)) return base;
+        if (isSlugAvailable(base, null)) return base;
         for (int i = 2; i <= 10; i++) {
             String candidate = SlugUtil.withSuffix(base, i);
-            if (!postRepository.existsBySlug(candidate)) return candidate;
+            if (isSlugAvailable(candidate, null)) return candidate;
         }
         return base + "-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    private void assertSlugAvailable(String slug, Long currentPostId) {
+        if (!isSlugAvailable(slug, currentPostId)) {
+            throw new DuplicateException(ErrorCode.DUPLICATE_POST_SLUG);
+        }
+    }
+
+    private boolean isSlugAvailable(String slug, Long currentPostId) {
+        boolean currentSlugAvailable = postRepository.findBySlug(slug)
+                .map(post -> post.getId().equals(currentPostId))
+                .orElse(true);
+        boolean oldSlugAvailable = postSlugHistoryRepository.findByOldSlug(slug)
+                .map(history -> history.getPost().getId().equals(currentPostId))
+                .orElse(true);
+        return currentSlugAvailable && oldSlugAvailable;
+    }
+
+    private void recordSlugHistoryIfChanged(Post post, String oldSlug, String newSlug) {
+        if (oldSlug == null || oldSlug.equals(newSlug)) {
+            return;
+        }
+        postSlugHistoryRepository.findByOldSlug(newSlug)
+                .filter(history -> history.getPost().getId().equals(post.getId()))
+                .ifPresent(postSlugHistoryRepository::delete);
+        if (!postSlugHistoryRepository.existsByOldSlug(oldSlug)) {
+            postSlugHistoryRepository.save(new PostSlugHistory(post, oldSlug));
+        }
     }
 }

--- a/backend/src/main/resources/sql/260526_post-slug-history.sql
+++ b/backend/src/main/resources/sql/260526_post-slug-history.sql
@@ -1,0 +1,14 @@
+CREATE TABLE post_slug_history (
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    post_id    BIGINT       NOT NULL,
+    old_slug   VARCHAR(255) NOT NULL,
+    changed_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_slug_history_old_slug (old_slug),
+    KEY ix_slug_history_post_id (post_id),
+    CONSTRAINT fk_slug_history_post
+        FOREIGN KEY (post_id) REFERENCES post(post_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- rollback
+-- DROP TABLE post_slug_history;

--- a/backend/src/test/java/com/moya/myblogboot/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/moya/myblogboot/controller/PostControllerTest.java
@@ -248,15 +248,16 @@ class PostControllerTest extends AbstractContainerBaseTest {
     }
 
     @Test
-    @DisplayName("게시글 상세 조회 V1 (slug) — 최초 조회: 조회수 증가 + viewed_posts 쿠키 발급")
-    void getPostDetailV1BySlug_최초조회() throws Exception {
+    @DisplayName("게시글 상세 조회 V1 (slug) — GET은 조회수 증가 없이 순수 조회")
+    void getPostDetailV1BySlug_doesNotIncrementViews() throws Exception {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(postId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.slug").value(postSlug))
-                .andExpect(MockMvcResultMatchers.cookie().exists("viewed_posts"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.views").value(0))
+                .andExpect(MockMvcResultMatchers.cookie().doesNotExist("viewed_posts"))
                 .andDo(restDocs.document(
                         pathParameters(
                                 parameterWithName("identifier").description("게시글 슬러그 또는 숫자 ID")
@@ -278,42 +279,68 @@ class PostControllerTest extends AbstractContainerBaseTest {
     }
 
     @Test
-    @DisplayName("게시글 상세 조회 V1 (slug) — 중복 조회: viewed_posts 쿠키 포함 시 조회수 증가 없음")
-    void getPostDetailV1BySlug_중복조회() throws Exception {
-        // 1차 조회로 쿠키 발급
-        MvcResult firstResult = mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug))
+    @DisplayName("게시글 조회수 증가 — POST만 증가하고 쿠키 중복 호출은 증가하지 않음")
+    void incrementPostViewsByPostOnlyDeduplicatesWithCookie() throws Exception {
+        MvcResult firstResult = mockMvc.perform(post("/api/v1/posts/{postId}/views", postId))
                 .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("1"))
                 .andReturn();
 
         Cookie viewedCookie = firstResult.getResponse().getCookie("viewed_posts");
         assertThat(viewedCookie).isNotNull();
 
-        long viewsAfterFirst = ((Number) new com.fasterxml.jackson.databind.ObjectMapper()
-                .readTree(firstResult.getResponse().getContentAsString())
-                .get("views").numberValue()).longValue();
-
-        // 2차 조회 (동일 쿠키 포함)
-        MvcResult secondResult = mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug)
+        mockMvc.perform(post("/api/v1/posts/{postId}/views", postId)
                         .cookie(viewedCookie))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andReturn();
+                .andExpect(MockMvcResultMatchers.content().string("1"));
 
-        long viewsAfterSecond = ((Number) new com.fasterxml.jackson.databind.ObjectMapper()
-                .readTree(secondResult.getResponse().getContentAsString())
-                .get("views").numberValue()).longValue();
-
-        assertThat(viewsAfterSecond).isEqualTo(viewsAfterFirst);
+        mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.views").value(1));
     }
 
     @Test
-    @DisplayName("게시글 상세 조회 V1 (ID) — 최초 조회: 조회수 증가 + viewed_posts 쿠키 발급")
-    void getPostDetailV1ById_최초조회() throws Exception {
+    @DisplayName("게시글 상세 조회 V1 (ID) — GET은 viewed_posts 쿠키를 발급하지 않음")
+    void getPostDetailV1ById_doesNotIssueViewedCookie() throws Exception {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/posts/{identifier}", postId));
 
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(postId))
-                .andExpect(MockMvcResultMatchers.cookie().exists("viewed_posts"));
+                .andExpect(MockMvcResultMatchers.cookie().doesNotExist("viewed_posts"));
+    }
+
+    @Test
+    @DisplayName("이전 slug 조회 — 현재 공개 slug로 301 Location 응답")
+    void getPostDetailByOldSlugReturns301ToCurrentSlug() throws Exception {
+        PostReqDto modifiedPostDto = PostReqDto.builder()
+                .title("modifiedTitle")
+                .content("modifiedContent")
+                .category(categoryId)
+                .slug("new-public-slug")
+                .build();
+
+        mockMvc.perform(put("/api/v1/posts/{postId}", postId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(modifiedPostDto)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        mockMvc.perform(get("/api/v1/posts/{identifier}", postSlug))
+                .andExpect(MockMvcResultMatchers.status().isMovedPermanently())
+                .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION,
+                        "http://localhost:8080/posts/new-public-slug"));
+    }
+
+    @Test
+    @DisplayName("조회수 증가 - HIDE 게시글은 404")
+    void incrementViewsHiddenPostReturns404() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.updatePostStatus(PostStatus.HIDE);
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/views", postId))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
     @Test
@@ -609,6 +636,16 @@ class PostControllerTest extends AbstractContainerBaseTest {
     }
 
     @Test
+    @DisplayName("게시글 좋아요 - HIDE 게시글은 404")
+    void addPostLikeHiddenPostReturns404() throws Exception {
+        Post post = postRepository.findById(postId).orElseThrow();
+        post.updatePostStatus(PostStatus.HIDE);
+
+        mockMvc.perform(post("/api/v2/likes/{postId}", postId))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
     @DisplayName("게시글 좋아요 여부 체크")
     void checkPostLike() throws Exception {
         // 좋아요 추가 후 발급된 쿠키 획득
@@ -748,5 +785,25 @@ class PostControllerTest extends AbstractContainerBaseTest {
                         ),
                         responseBody()
                 ));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 - 삭제 게시글은 410")
+    void cancelPostLikeDeletedPostReturns410() throws Exception {
+        MvcResult likeResult = mockMvc.perform(post("/api/v2/likes/{postId}", postId))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        Cookie likedCookie = likeResult.getResponse().getCookie(CookieName.LIKED_POSTS);
+        assertThat(likedCookie).isNotNull();
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/posts/" + postId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .cookie(new Cookie(CookieName.ACCESS_TOKEN_COOKIE, accessToken)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        mockMvc.perform(delete("/api/v2/likes/{postId}", postId)
+                        .cookie(likedCookie))
+                .andExpect(MockMvcResultMatchers.status().isGone())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("B005"));
     }
 }


### PR DESCRIPTION
## Summary
  - 게시글 slug 변경/정규화 시 리다이렉트 흐름을 명확히 분리
  - 게시글 조회 시 자동 조회수 증가와 별도 조회수 증가 API 책임을 분리
  - 게시글 상세 조회 API의 읽기 동작과 조회수 증가 부작용을 분리해 API 계약을 명확화

  ## Tests
  - [ x] 관련 서비스 단위 테스트
  - [ x] 게시글 상세 조회 API 테스트
  - [ x] 조회수 증가 API 테스트
  - [ x] slug 리다이렉트 동작 테스트